### PR TITLE
fix(dashboards): correct queries and add missing panels for Perses and Plutono

### DIFF
--- a/dashboards/repoguard-status-ops-perses.json
+++ b/dashboards/repoguard-status-ops-perses.json
@@ -222,7 +222,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "sum by (operation) (repo_guard_githubteam_operations{state=\"complete\", organization=~\"$org\", team=~\"$team\"}) + sum by (operation) (repo_guard_githuborganization_operations{scope=\"owners\", state=\"complete\", github=~\"$github\", organization=~\"$org\"})",
+                    "query": "sum by (operation) (increase(repo_guard_githubteam_operations{state=\"complete\", organization=~\"$org\", team=~\"$team\"}[5m])) + sum by (operation) (increase(repo_guard_githuborganization_operations{scope=\"owners\", state=\"complete\", github=~\"$github\", organization=~\"$org\"}[5m]))",
                     "seriesNameFormat": "Member {{operation}}"
                   }
                 }
@@ -399,7 +399,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "sum by (scope, operation) (repo_guard_githuborganization_operations{scope=~\"teams|repos\", state=\"complete\", github=~\"$github\", organization=~\"$org\"})",
+                    "query": "sum by (scope, operation) (increase(repo_guard_githuborganization_operations{scope=~\"teams|repos\", state=\"complete\", github=~\"$github\", organization=~\"$org\"}[5m]))",
                     "seriesNameFormat": "{{scope}} {{operation}}"
                   }
                 }

--- a/dashboards/repoguard-status-ops-plutono.json
+++ b/dashboards/repoguard-status-ops-plutono.json
@@ -168,7 +168,7 @@
       "title": "🏢 Organizations Needing Attention",
       "type": "table",
       "targets": [
-        { "expr": "sum by (organization, status) (repo_guard_githuborganization_status{github=~\"$github\", organization=~\"$org\", status=~\"failed|ratelimited|pending\"} == 1)", "format": "table", "instant": true, "refId": "A" }
+        { "expr": "sum by (github, organization, status) (repo_guard_githuborganization_status{github=~\"$github\", organization=~\"$org\", status=~\"failed|ratelimited|pending\"} == 1)", "format": "table", "instant": true, "refId": "A" }
       ]
     },
     {
@@ -276,7 +276,7 @@
       "title": "🚦 Rate Limit Status",
       "type": "stat",
       "targets": [
-        { "expr": "sum(repo_guard_githuborganization_status{status=\"ratelimited\"} == 1) or vector(0)", "refId": "A" }
+        { "expr": "sum(repo_guard_githuborganization_status{status=\"ratelimited\", github=~\"$github\", organization=~\"$org\"} == 1) or vector(0)", "refId": "A" }
       ]
     },
     {
@@ -299,6 +299,61 @@
       "type": "timeseries",
       "targets": [
         { "expr": "histogram_quantile(0.95, sum by (le, controller) (rate(repo_guard_controller_reconcile_duration_seconds_bucket[5m])))", "legendFormat": "{{controller}} p95", "refId": "A" }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "id": 500,
+      "panels": [],
+      "title": "📋 Full Status Overview",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "displayMode": "color-background-status" },
+          "mappings": [
+            { "options": { "failed": { "color": "red", "index": 0 }, "ratelimited": { "color": "yellow", "index": 1 }, "pending": { "color": "orange", "index": 2 }, "complete": { "color": "green", "index": 3 } }, "type": "value" }
+          ]
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "organization" }, "properties": [ { "id": "custom.width", "value": 200 } ] },
+          { "matcher": { "id": "byName", "options": "status" }, "properties": [ { "id": "custom.width", "value": 150 } ] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "id": 50,
+      "options": { "footer": { "show": false }, "showHeader": true },
+      "title": "🏢 Organizations Status",
+      "type": "table",
+      "targets": [
+        { "expr": "sum by (github, organization, status) (repo_guard_githuborganization_status{github=~\"$github\", organization=~\"$org\"} == 1)", "format": "table", "instant": true, "refId": "A" }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "displayMode": "color-background-status" },
+          "mappings": [
+            { "options": { "failed": { "color": "red", "index": 0 }, "ratelimited": { "color": "yellow", "index": 1 }, "pending": { "color": "orange", "index": 2 }, "complete": { "color": "green", "index": 3 } }, "type": "value" }
+          ]
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "organization" }, "properties": [ { "id": "custom.width", "value": 150 } ] },
+          { "matcher": { "id": "byName", "options": "team" }, "properties": [ { "id": "custom.width", "value": 250 } ] },
+          { "matcher": { "id": "byName", "options": "status" }, "properties": [ { "id": "custom.width", "value": 150 } ] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "id": 51,
+      "options": { "footer": { "show": false }, "showHeader": true },
+      "title": "👥 Teams Status",
+      "type": "table",
+      "targets": [
+        { "expr": "sum by (organization, team, status) (repo_guard_githubteam_status{organization=~\"$org\", team=~\"$team\"} == 1)", "format": "table", "instant": true, "refId": "A" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary

- **Perses** — `peopleOps` and `teamRepoOps` panels were summing raw counter values directly, producing monotonically increasing lines instead of rates. Wrapped both queries in `increase([5m])`.
- **Plutono** — `orgsAttention` table was missing `github` in `sum by(...)`, causing the github column to not appear.
- **Plutono** — `rateLimitStatus` stat panel was ignoring the `$github` and `$org` template variables, always showing counts across all instances.
- **Plutono** — Added the missing `Organizations Status` and `Teams Status` full-overview table panels (present in Perses but absent from Plutono), including colour mappings and column width overrides.
 