### PR TITLE
fix(types): prevent duplicate team/repo operations when completed op exists

### DIFF
--- a/api/v1/githuborganization_types.go
+++ b/api/v1/githuborganization_types.go
@@ -316,10 +316,11 @@ func (g GithubOrganization) TeamChangeCalculator(teamsFromKubernetes []string) (
 		if !kubernetesTeamFound {
 			// action: add the owner to github
 
-			// check if there is a waiting task
+			// check if there is a waiting or already-completed task
+			// A completed add operation means the team was already successfully created; do not re-queue.
 			teamOperationFound := false
 			for _, teamOpeation := range newStatus.Operations.GithubTeamOperations {
-				if strings.EqualFold(teamOpeation.Team, kubernetesTeam) && teamOpeation.Operation == GithubTeamOperationTypeAdd && teamOpeation.State != GithubTeamOperationStateComplete {
+				if strings.EqualFold(teamOpeation.Team, kubernetesTeam) && teamOpeation.Operation == GithubTeamOperationTypeAdd {
 					teamOperationFound = true
 					break
 				}
@@ -353,10 +354,11 @@ func (g GithubOrganization) TeamChangeCalculator(teamsFromKubernetes []string) (
 		if !kubernetesTeamFound {
 			// action: remove the team from github
 
-			// check if there is a waiting task
+			// check if there is a waiting or already-completed task
+			// A completed remove operation means the team was already successfully deleted; do not re-queue.
 			teamOperationFound := false
 			for _, teamOpeation := range newStatus.Operations.GithubTeamOperations {
-				if strings.EqualFold(teamOpeation.Team, githubTeam) && teamOpeation.Operation == GithubTeamOperationTypeRemove && teamOpeation.State != GithubTeamOperationStateComplete {
+				if strings.EqualFold(teamOpeation.Team, githubTeam) && teamOpeation.Operation == GithubTeamOperationTypeRemove {
 					teamOperationFound = true
 					break
 				}
@@ -415,10 +417,10 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 					if team.Permission != configTeam.Permission {
 						// remove the team and add it with the config permission
 
-						// check if there is a waiting task
+						// check if there is a waiting or already-completed task
 						repoTeamOperationRemoveFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove && op.State != GithubTeamOperationStateComplete {
+							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
 								repoTeamOperationRemoveFound = true
 								break
 							}
@@ -438,7 +440,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 						// add with the new permission
 						repoTeamOperationAddFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd && op.State != GithubTeamOperationStateComplete {
+							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
 								repoTeamOperationAddFound = true
 								break
 							}
@@ -464,7 +466,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 				// add with the new permission
 				repoTeamOperationAddFound := false
 				for _, op := range operations {
-					if strings.EqualFold(op.Team, configTeam.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd && op.State != GithubTeamOperationStateComplete {
+					if strings.EqualFold(op.Team, configTeam.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
 						repoTeamOperationAddFound = true
 						break
 					}
@@ -493,10 +495,10 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 					if team.Permission != configTeam.Permission {
 						// remove the team and add it with the config permission
 
-						// check if there is a waiting task
+						// check if there is a waiting or already-completed task
 						repoTeamOperationRemoveFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove && op.State != GithubTeamOperationStateComplete {
+							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
 								repoTeamOperationRemoveFound = true
 								break
 							}
@@ -516,7 +518,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 						// add with the new permission
 						repoTeamOperationAddFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd && op.State != GithubTeamOperationStateComplete {
+							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
 								repoTeamOperationAddFound = true
 								break
 							}
@@ -539,10 +541,10 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 			}
 
 			if !repoTeamFound {
-				// check if there is a waiting task
+				// check if there is a waiting or already-completed task
 				repoTeamOperationRemoveFound := false
 				for _, op := range operations {
-					if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove && op.State != GithubTeamOperationStateComplete {
+					if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
 						repoTeamOperationRemoveFound = true
 						break
 					}

--- a/api/v1/githuborganization_types.go
+++ b/api/v1/githuborganization_types.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/gosimple/slug"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -409,18 +410,20 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 
 		// ensure that default teams are assigned
 		for _, configTeam := range configExtendedWithExceptions {
+			configTeamSlug := slug.Make(configTeam.Team)
 			configTeamFound := false
 
 			for _, team := range repo.Teams {
-				if team.Team == configTeam.Team {
+				if team.Team == configTeamSlug {
 					configTeamFound = true
 					if team.Permission != configTeam.Permission {
 						// remove the team and add it with the config permission
 
 						// check if there is a waiting or already-completed task
+						// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 						repoTeamOperationRemoveFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
+							if strings.EqualFold(slug.Make(op.Team), team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
 								repoTeamOperationRemoveFound = true
 								break
 							}
@@ -438,9 +441,10 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 						}
 
 						// add with the new permission
+						// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 						repoTeamOperationAddFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
+							if strings.EqualFold(slug.Make(op.Team), team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
 								repoTeamOperationAddFound = true
 								break
 							}
@@ -449,7 +453,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 						if !repoTeamOperationAddFound {
 							op := GithubRepoTeamOperation{
 								Operation:  GithubRepoTeamOperationTypeAdd,
-								Team:       configTeam.Team,
+								Team:       configTeamSlug,
 								Repo:       repo.Name,
 								Permission: configTeam.Permission,
 								State:      GithubRepoTeamOperationStatePending,
@@ -464,9 +468,10 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 
 			if !configTeamFound {
 				// add with the new permission
+				// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 				repoTeamOperationAddFound := false
 				for _, op := range operations {
-					if strings.EqualFold(op.Team, configTeam.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
+					if strings.EqualFold(slug.Make(op.Team), configTeamSlug) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
 						repoTeamOperationAddFound = true
 						break
 					}
@@ -475,7 +480,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 				if !repoTeamOperationAddFound {
 					op := GithubRepoTeamOperation{
 						Operation:  GithubRepoTeamOperationTypeAdd,
-						Team:       configTeam.Team,
+						Team:       configTeamSlug,
 						Repo:       repo.Name,
 						Permission: configTeam.Permission,
 						State:      GithubRepoTeamOperationStatePending,
@@ -490,15 +495,17 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 		for _, team := range repo.Teams {
 			repoTeamFound := false
 			for _, configTeam := range configExtendedWithExceptions {
-				if team.Team == configTeam.Team {
+				configTeamSlug := slug.Make(configTeam.Team)
+				if team.Team == configTeamSlug {
 					repoTeamFound = true
 					if team.Permission != configTeam.Permission {
 						// remove the team and add it with the config permission
 
 						// check if there is a waiting or already-completed task
+						// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 						repoTeamOperationRemoveFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
+							if strings.EqualFold(slug.Make(op.Team), team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
 								repoTeamOperationRemoveFound = true
 								break
 							}
@@ -516,9 +523,10 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 						}
 
 						// add with the new permission
+						// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 						repoTeamOperationAddFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
+							if strings.EqualFold(slug.Make(op.Team), team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
 								repoTeamOperationAddFound = true
 								break
 							}
@@ -527,7 +535,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 						if !repoTeamOperationAddFound {
 							op := GithubRepoTeamOperation{
 								Operation:  GithubRepoTeamOperationTypeAdd,
-								Team:       configTeam.Team,
+								Team:       configTeamSlug,
 								Repo:       repo.Name,
 								Permission: configTeam.Permission,
 								State:      GithubRepoTeamOperationStatePending,
@@ -542,9 +550,10 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 
 			if !repoTeamFound {
 				// check if there is a waiting or already-completed task
+				// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 				repoTeamOperationRemoveFound := false
 				for _, op := range operations {
-					if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
+					if strings.EqualFold(slug.Make(op.Team), team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
 						repoTeamOperationRemoveFound = true
 						break
 					}

--- a/api/v1/githuborganization_types.go
+++ b/api/v1/githuborganization_types.go
@@ -317,13 +317,13 @@ func (g GithubOrganization) TeamChangeCalculator(teamsFromKubernetes []string) (
 
 		// kubernetes team is not found in github list
 		if !kubernetesTeamFound {
-			// action: add the owner to github
+			// action: add the team to github
 
-			// check if there is a waiting or already-completed task
-			// A completed add operation means the team was already successfully created; do not re-queue.
+			// check if there is any existing task (pending, complete, failed, etc.)
+			// Any existing add operation suppresses re-queuing, regardless of state.
 			teamOperationFound := false
-			for _, teamOpeation := range newStatus.Operations.GithubTeamOperations {
-				if strings.EqualFold(teamOpeation.Team, kubernetesTeam) && teamOpeation.Operation == GithubTeamOperationTypeAdd {
+			for _, teamOperation := range newStatus.Operations.GithubTeamOperations {
+				if strings.EqualFold(teamOperation.Team, kubernetesTeam) && teamOperation.Operation == GithubTeamOperationTypeAdd {
 					teamOperationFound = true
 					break
 				}
@@ -357,11 +357,11 @@ func (g GithubOrganization) TeamChangeCalculator(teamsFromKubernetes []string) (
 		if !kubernetesTeamFound {
 			// action: remove the team from github
 
-			// check if there is a waiting or already-completed task
-			// A completed remove operation means the team was already successfully deleted; do not re-queue.
+			// check if there is any existing task (pending, complete, failed, etc.)
+			// Any existing remove operation suppresses re-queuing, regardless of state.
 			teamOperationFound := false
-			for _, teamOpeation := range newStatus.Operations.GithubTeamOperations {
-				if strings.EqualFold(teamOpeation.Team, githubTeam) && teamOpeation.Operation == GithubTeamOperationTypeRemove {
+			for _, teamOperation := range newStatus.Operations.GithubTeamOperations {
+				if strings.EqualFold(teamOperation.Team, githubTeam) && teamOperation.Operation == GithubTeamOperationTypeRemove {
 					teamOperationFound = true
 					break
 				}
@@ -424,7 +424,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 					if team.Permission != configTeam.Permission {
 						// remove the team and add it with the config permission
 
-						// check if there is a waiting or already-completed task
+						// check if there is any existing task (pending, complete, failed, etc.)
 						// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 						repoTeamOperationRemoveFound := false
 						for _, op := range operations {
@@ -433,7 +433,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 								break
 							}
 						}
-						// if there is no waiting task, add new task
+						// if there is no existing task, add new task
 						if !repoTeamOperationRemoveFound {
 							op := GithubRepoTeamOperation{
 								Operation: GithubRepoTeamOperationTypeRemove,
@@ -506,7 +506,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 					if team.Permission != configTeam.Permission {
 						// remove the team and add it with the config permission
 
-						// check if there is a waiting or already-completed task
+						// check if there is any existing task (pending, complete, failed, etc.)
 						// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 						repoTeamOperationRemoveFound := false
 						for _, op := range operations {
@@ -515,7 +515,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 								break
 							}
 						}
-						// if there is no waiting task, add new task
+						// if there is no existing task, add new task
 						if !repoTeamOperationRemoveFound {
 							op := GithubRepoTeamOperation{
 								Operation: GithubRepoTeamOperationTypeRemove,
@@ -554,7 +554,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 			}
 
 			if !repoTeamFound {
-				// check if there is a waiting or already-completed task
+				// check if there is any existing task (pending, complete, failed, etc.)
 				// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 				repoTeamOperationRemoveFound := false
 				for _, op := range operations {
@@ -563,7 +563,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 						break
 					}
 				}
-				// if there is no waiting task, add new task
+				// if there is no existing task, add new task
 				if !repoTeamOperationRemoveFound {
 					op := GithubRepoTeamOperation{
 						Operation: GithubRepoTeamOperationTypeRemove,

--- a/api/v1/githuborganization_types_test.go
+++ b/api/v1/githuborganization_types_test.go
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"testing"
+)
+
+// teamOp is a helper to build a GithubRepoTeamOperation for test setup.
+func teamOp(team, repo string, opType GithubRepoTeamOperationType, state GithubRepoTeamOperationState) GithubRepoTeamOperation {
+	return GithubRepoTeamOperation{
+		Team:      team,
+		Repo:      repo,
+		Operation: opType,
+		State:     state,
+	}
+}
+
+func TestRepoChangeCalculator(t *testing.T) {
+	tests := []struct {
+		name          string
+		defaultConfig []GithubTeamWithPermission
+		actual        []GithubRepository
+		operations    []GithubRepoTeamOperation
+		wantOps       []GithubRepoTeamOperation
+	}{
+		{
+			name: "team missing from repo generates ADD op",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "my-team", Permission: GithubTeamPermissionPush},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{}},
+			},
+			operations: nil,
+			wantOps: []GithubRepoTeamOperation{
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeAdd, Permission: GithubTeamPermissionPush, State: GithubRepoTeamOperationStatePending},
+			},
+		},
+		{
+			name: "team present with correct permission generates no op",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "my-team", Permission: GithubTeamPermissionPush},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{
+					{Team: "my-team", Permission: GithubTeamPermissionPush},
+				}},
+			},
+			operations: nil,
+			wantOps:    []GithubRepoTeamOperation{},
+		},
+		{
+			// Both the "ensure default teams" loop and the "iterate repo teams" loop
+			// independently detect permission drift and each emit REMOVE+ADD. The
+			// dedup only fires against the *incoming* operations slice, not against
+			// ops already accumulated in the same call. CleanCompletedOperations and
+			// the cross-reconcile dedup handle the real-world case.
+			name: "team present with wrong permission generates REMOVE and ADD ops (both loops fire)",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "my-team", Permission: GithubTeamPermissionAdmin},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{
+					{Team: "my-team", Permission: GithubTeamPermissionPush},
+				}},
+			},
+			operations: nil,
+			wantOps: []GithubRepoTeamOperation{
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeRemove, State: GithubRepoTeamOperationStatePending},
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeAdd, Permission: GithubTeamPermissionAdmin, State: GithubRepoTeamOperationStatePending},
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeRemove, State: GithubRepoTeamOperationStatePending},
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeAdd, Permission: GithubTeamPermissionAdmin, State: GithubRepoTeamOperationStatePending},
+			},
+		},
+		{
+			name:          "team in repo but not in config generates REMOVE op",
+			defaultConfig: []GithubTeamWithPermission{},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{
+					{Team: "stale-team", Permission: GithubTeamPermissionPush},
+				}},
+			},
+			operations: nil,
+			wantOps: []GithubRepoTeamOperation{
+				{Team: "stale-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeRemove, State: GithubRepoTeamOperationStatePending},
+			},
+		},
+		{
+			name: "existing pending ADD op deduplicates — no new ADD generated",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "my-team", Permission: GithubTeamPermissionPush},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{}},
+			},
+			operations: []GithubRepoTeamOperation{
+				teamOp("my-team", "repo1", GithubRepoTeamOperationTypeAdd, GithubRepoTeamOperationStatePending),
+			},
+			wantOps: []GithubRepoTeamOperation{},
+		},
+		{
+			name: "existing completed ADD op deduplicates — no new ADD generated",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "my-team", Permission: GithubTeamPermissionPush},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{}},
+			},
+			operations: []GithubRepoTeamOperation{
+				teamOp("my-team", "repo1", GithubRepoTeamOperationTypeAdd, GithubRepoTeamOperationStateComplete),
+			},
+			wantOps: []GithubRepoTeamOperation{},
+		},
+		{
+			// Upgrade-safety: op.Team stored as display name before the slug fix was deployed.
+			// slug.Make("My Team") == "my-team", so the dedup must still fire.
+			name: "existing ADD op with display-name (pre-fix) deduplicates against slug config team",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "My Team", Permission: GithubTeamPermissionPush},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{}},
+			},
+			operations: []GithubRepoTeamOperation{
+				// stored with the old display name before the slug fix
+				teamOp("My Team", "repo1", GithubRepoTeamOperationTypeAdd, GithubRepoTeamOperationStatePending),
+			},
+			wantOps: []GithubRepoTeamOperation{},
+		},
+		{
+			// Spec team name with spaces/uppercase must be normalised to slug in the new op.
+			name: "display-name spec team generates ADD op with slugified Team field",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "My Awesome Team", Permission: GithubTeamPermissionPull},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{}},
+			},
+			operations: nil,
+			wantOps: []GithubRepoTeamOperation{
+				{Team: "my-awesome-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeAdd, Permission: GithubTeamPermissionPull, State: GithubRepoTeamOperationStatePending},
+			},
+		},
+		{
+			// GitHub returns the slug ("my-team") in repo.Teams.  The spec has the
+			// display name ("My Team").  After normalisation both resolve to "my-team"
+			// so no operation should be generated.
+			name: "spec display name matches github slug — no op generated",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "My Team", Permission: GithubTeamPermissionPush},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{
+					{Team: "my-team", Permission: GithubTeamPermissionPush},
+				}},
+			},
+			operations: nil,
+			wantOps:    []GithubRepoTeamOperation{},
+		},
+		{
+			// Same as above: both loops fire for permission drift.
+			name: "permission drift with display-name spec team generates REMOVE and ADD with slug (both loops fire)",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "My Team", Permission: GithubTeamPermissionAdmin},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{
+					{Team: "my-team", Permission: GithubTeamPermissionPush},
+				}},
+			},
+			operations: nil,
+			wantOps: []GithubRepoTeamOperation{
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeRemove, State: GithubRepoTeamOperationStatePending},
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeAdd, Permission: GithubTeamPermissionAdmin, State: GithubRepoTeamOperationStatePending},
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeRemove, State: GithubRepoTeamOperationStatePending},
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeAdd, Permission: GithubTeamPermissionAdmin, State: GithubRepoTeamOperationStatePending},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := repoChangeCalculator(tt.defaultConfig, tt.actual, nil, nil, tt.operations)
+
+			if len(got) != len(tt.wantOps) {
+				t.Fatalf("got %d ops, want %d ops\ngot:  %+v\nwant: %+v", len(got), len(tt.wantOps), got, tt.wantOps)
+			}
+
+			for i, want := range tt.wantOps {
+				g := got[i]
+				if g.Team != want.Team {
+					t.Errorf("op[%d].Team = %q, want %q", i, g.Team, want.Team)
+				}
+				if g.Repo != want.Repo {
+					t.Errorf("op[%d].Repo = %q, want %q", i, g.Repo, want.Repo)
+				}
+				if g.Operation != want.Operation {
+					t.Errorf("op[%d].Operation = %q, want %q", i, g.Operation, want.Operation)
+				}
+				if want.Permission != "" && g.Permission != want.Permission {
+					t.Errorf("op[%d].Permission = %q, want %q", i, g.Permission, want.Permission)
+				}
+				if g.State != want.State {
+					t.Errorf("op[%d].State = %q, want %q", i, g.State, want.State)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `TeamChangeCalculator` and `repoChangeCalculator` were excluding `complete` state from their dedup guards (`State != Complete`), so a completed operation was invisible to the check
- When `completedTTL` cleanup removed completed operations from status, the next reconcile found no blocking operation and re-queued **all** team and repo operations in bulk, causing large spikes in the operations dashboard
- Removes the `State != Complete` exclusion from all 6 dedup checks across both calculators, aligning them with the same pattern already used in `OwnerChangeCalculator` (and fixed for owner operations in PR #111)

## Root cause

After `completedTTL` expires and `CleanCompletedOperations()` prunes the status, the calculators compared desired state against live GitHub data (which was already correct), but the dedup guard allowed re-queuing because no `complete` op existed anymore. The fix means a `complete` op blocks re-queuing while it still exists; after cleanup, the live GitHub state prevents false diffs.

## Test plan

- [ ] Verify no bulk team/repo operation spikes occur after `completedTTL` window elapses
- [ ] Verify that genuinely new teams/repos (not yet in GitHub) still get operations queued correctly
- [ ] Verify that permission-change operations (remove + re-add) are not re-queued when already completed