### PR TITLE
feat(commands): add /review-pr slash command for Claude Code

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,6 +1,6 @@
 # review-pr
 
-Review an open pull request, assess every comment for validity, implement valid fixes (with approval), and reply to invalid ones.
+Review an open pull request, assess every comment for validity, implement valid fixes (with approval), reply to all threads, resolve them, and — when Copilot is the reviewer — iterate until Copilot raises no further comments.
 
 ## Usage
 
@@ -9,6 +9,8 @@ Review an open pull request, assess every comment for validity, implement valid 
 ```
 
 ## What this command does
+
+This command runs as a **loop**:
 
 1. **Fetch comments** — retrieve all inline review comments and conversation comments from the PR using `gh api`.
 
@@ -26,7 +28,17 @@ Review an open pull request, assess every comment for validity, implement valid 
    - Commit with a DCO sign-off (`git commit -s`) following the `type(scope): description` style from `AGENTS.md`.
    - Push to the PR branch.
 
-5. **Reply to every comment** — after each fix is pushed, post a reply to the original thread referencing the commit. For stale or invalid comments, post a factual explanation of why no code change was made.
+5. **Reply to every comment** — after each fix is pushed, post a reply to the original thread referencing the commit SHA. For stale or invalid comments, post a factual explanation of why no code change was made.
+
+6. **Resolve every thread** — mark all comment threads as resolved via the GraphQL API.
+
+7. **Re-request review if Copilot was the reviewer** — if `copilot-pull-request-reviewer[bot]` was among the reviewers, re-request its review so it re-evaluates the updated code.
+
+8. **Wait and iterate** — poll the PR for new comments. Once Copilot posts its next review, go back to step 1. The loop exits when either:
+   - All threads are resolved and Copilot posts no new comments, **or**
+   - Copilot was not a reviewer (no loop needed).
+
+---
 
 ## Steps in detail
 
@@ -48,10 +60,12 @@ git diff main...HEAD -- <changed-files>
 
 ### 2 — Assess comments
 
-For each comment:
+For each **unresolved** comment thread:
 - Quote the comment body.
 - Show the diff hunk it points at.
 - State: **Valid** / **Stale** / **Invalid** with a one-paragraph rationale.
+
+Skip threads that are already resolved (`isResolved: true`).
 
 ### 3 — Get approval
 
@@ -94,10 +108,12 @@ gh api repos/cloudoperators/repo-guard/pulls/<PR>/comments \
 
 Note: use `in_reply_to` (not a `/replies` sub-resource — that endpoint does not exist for PR review comments).
 
+### 6 — Resolve every thread
+
 After replying, resolve the thread via the GraphQL API (there is no REST endpoint for this):
 
 ```bash
-# Step 1 — get the thread node IDs
+# Step 1 — get the thread node IDs and their resolved state
 gh api graphql -f query='
 {
   repository(owner: "cloudoperators", name: "repo-guard") {
@@ -115,7 +131,7 @@ gh api graphql -f query='
   }
 }'
 
-# Step 2 — resolve each thread by its node ID
+# Step 2 — resolve each unresolved thread by its node ID
 gh api graphql -f query='
 mutation {
   resolveReviewThread(input: {threadId: "<THREAD_NODE_ID>"}) {
@@ -123,6 +139,64 @@ mutation {
   }
 }'
 ```
+
+### 7 — Re-request Copilot review (if applicable)
+
+Check whether `copilot-pull-request-reviewer[bot]` appears in the reviewer list:
+
+```bash
+gh api repos/cloudoperators/repo-guard/pulls/<PR>/requested_reviewers
+```
+
+If Copilot was a reviewer, re-request its review so it re-evaluates the updated diff:
+
+```bash
+gh api repos/cloudoperators/repo-guard/pulls/<PR>/requested_reviewers \
+  --method POST \
+  --field "reviewers[]=" \
+  --field "team_reviewers[]=copilot-pull-request-reviewer"
+```
+
+If the bot cannot be requested directly by name, trigger re-review via the GitHub UI note in the reply, or use:
+
+```bash
+gh pr review <PR> --repo cloudoperators/repo-guard --request-changes --body "" 2>/dev/null || true
+# Then re-approve to trigger Copilot
+```
+
+The reliable approach is:
+
+```bash
+gh api repos/cloudoperators/repo-guard/pulls/<PR>/reviews \
+  --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length'
+```
+
+If the count is > 0 and Copilot was the only reviewer, re-request by dismissing its last review or simply pushing a new commit (Copilot re-triggers automatically on new pushes to the PR branch in most configurations).
+
+### 8 — Wait and poll for new comments
+
+After re-requesting, poll until a new Copilot review appears:
+
+```bash
+# Poll every 30 seconds, up to 20 minutes
+for i in $(seq 1 40); do
+  NEW_COUNT=$(gh api repos/cloudoperators/repo-guard/pulls/<PR>/comments \
+    --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length')
+  echo "Attempt $i: $NEW_COUNT Copilot comments found"
+  [ "$NEW_COUNT" -gt "$PREVIOUS_COUNT" ] && break
+  sleep 30
+done
+```
+
+Once new comments appear, return to **step 1** with the new unresolved threads.
+
+### Exit condition
+
+The loop terminates when:
+- All review threads are `isResolved: true`, **and**
+- The latest Copilot review contains no new inline comments (review body only, or no review at all).
+
+---
 
 ## Conventions (from AGENTS.md)
 
@@ -133,20 +207,30 @@ mutation {
 - No CRD changes needed unless `_types.go` struct fields changed — if they did, run `make manifests generate`.
 - After any fix, run `make controller-test` and confirm all specs pass.
 
+---
+
 ## Example session
 
 ```
 User:  /review-pr 113
-Agent: Fetches comments from PR #113.
-       Presents: Comment 1 (Valid) — normalize op.Team in dedup checks ...
-                 Comment 2 (Valid) — add unit tests ...
-                 Comment 3 (Stale) — wrong constant reference, but the line no longer exists ...
-       Asks for approval.
-User:  Implement the valid ones, reply to all of them.
-Agent: Edits api/v1/githuborganization_types.go, adds test file,
-       runs make controller-test, commits (167822c), pushes.
-       Posts reply to Comment 1: "Fixed in commit 167822c. All six dedup loops now..."
-       Posts reply to Comment 2: "Fixed in commit 167822c. Added TestRepoChangeCalculator..."
-       Posts reply to Comment 3: "This line no longer exists in the diff..."
-       Resolves all three threads via GraphQL resolveReviewThread mutation.
+
+--- Iteration 1 ---
+Agent: Fetches comments. Finds 3 unresolved Copilot threads.
+       Presents assessments (2 valid, 1 stale). Gets approval.
+       Implements fixes, runs make controller-test, commits 167822c, pushes.
+       Replies to all 3 threads. Resolves all 3 threads.
+       Detects Copilot was the reviewer → re-requests Copilot review.
+       Polls for new comments...
+
+--- Iteration 2 ---
+Agent: New Copilot review detected (1 new comment).
+       Presents assessment (1 valid). Gets approval.
+       Implements fix, commits a2f91cc, pushes.
+       Replies to thread. Resolves thread.
+       Re-requests Copilot review. Polls for new comments...
+
+--- Iteration 3 ---
+Agent: Copilot review posted — no inline comments (summary only).
+       All threads resolved. Loop complete.
+       Informs user: PR is clean, no further Copilot comments.
 ```

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,107 @@
+# review-pr
+
+Review an open pull request, assess every comment for validity, implement valid fixes (with approval), and reply to invalid ones.
+
+## Usage
+
+```
+/review-pr <PR-number-or-URL>
+```
+
+## What this command does
+
+1. **Fetch comments** — retrieve all inline review comments and conversation comments from the PR using `gh api`.
+
+2. **Assess each comment** — for every comment decide:
+   - **Valid**: the comment identifies a real bug, correctness issue, or meaningful improvement in the code *as it exists in the PR diff*.
+   - **Stale/inapplicable**: the comment refers to a line that no longer exists or a condition that the PR has already addressed.
+   - **Invalid/disagree**: the suggested change would be incorrect, harmful, or violates project conventions.
+
+3. **Present findings** — explain each comment and your assessment to the user before touching any code. Get explicit approval to proceed.
+
+4. **Implement valid fixes** — for approved valid comments:
+   - Read the relevant files first.
+   - Apply the minimal change that addresses the comment.
+   - Run `make controller-test` to verify nothing is broken.
+   - Commit with a DCO sign-off (`git commit -s`) following the `type(scope): description` style from `AGENTS.md`.
+   - Push to the PR branch.
+
+5. **Reply to stale or invalid comments** — for comments that should not be acted on, compose a short, factual reply explaining why and (if the platform supports it) resolve the thread. Get user approval before posting.
+
+## Steps in detail
+
+### 1 — Gather PR data
+
+Run all three commands in parallel:
+
+```bash
+gh pr view <PR> --repo cloudoperators/repo-guard --json title,body,comments,reviews,url
+gh api repos/cloudoperators/repo-guard/pulls/<PR>/reviews
+gh api repos/cloudoperators/repo-guard/pulls/<PR>/comments
+```
+
+Also read the current branch to understand what the PR has already changed:
+
+```bash
+git diff main...HEAD -- <changed-files>
+```
+
+### 2 — Assess comments
+
+For each comment:
+- Quote the comment body.
+- Show the diff hunk it points at.
+- State: **Valid** / **Stale** / **Invalid** with a one-paragraph rationale.
+
+### 3 — Get approval
+
+Present the full assessment and ask the user whether to proceed before making any change.
+
+### 4 — Implement fixes
+
+For each approved valid fix:
+
+1. Read the full file (`Read` tool).
+2. Apply the change (`Edit` tool — prefer targeted edits over full rewrites).
+3. Run tests: `go test ./api/v1/... -v` then `make controller-test`.
+4. If tests pass, commit and push:
+
+```bash
+git add <files>
+git commit -s -m "fix(scope): <description>"
+git push origin <branch>
+```
+
+### 5 — Reply to non-actionable comments
+
+Post a concise reply via the GitHub API:
+
+```bash
+gh api repos/cloudoperators/repo-guard/pulls/comments/<comment-id>/replies \
+  --method POST \
+  --field body="<reply text>"
+```
+
+## Conventions (from AGENTS.md)
+
+- All commits must be signed off (`-s`).
+- Commit style: `type(scope): short description` — e.g. `fix(types): normalize team slugs`.
+- Do **not** add `Co-authored-by` trailers.
+- Run `make fmt` before committing if you touched Go files.
+- No CRD changes needed unless `_types.go` struct fields changed — if they did, run `make manifests generate`.
+- After any fix, run `make controller-test` and confirm all specs pass.
+
+## Example session
+
+```
+User:  /review-pr 113
+Agent: Fetches comments from PR #113.
+       Presents: Comment 1 (Valid) — normalize op.Team in dedup checks ...
+                 Comment 2 (Valid) — add unit tests ...
+                 Comment 3 (Stale) — wrong constant reference, but the line no longer exists ...
+       Asks for approval.
+User:  Implement the valid ones, reply to the stale one.
+Agent: Edits api/v1/githuborganization_types.go, adds test file,
+       runs make controller-test, commits, pushes.
+       Posts reply to Comment 3 explaining it is stale.
+```

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -26,7 +26,7 @@ Review an open pull request, assess every comment for validity, implement valid 
    - Commit with a DCO sign-off (`git commit -s`) following the `type(scope): description` style from `AGENTS.md`.
    - Push to the PR branch.
 
-5. **Reply to stale or invalid comments** — for comments that should not be acted on, compose a short, factual reply explaining why and (if the platform supports it) resolve the thread. Get user approval before posting.
+5. **Reply to every comment** — after each fix is pushed, post a reply to the original thread referencing the commit. For stale or invalid comments, post a factual explanation of why no code change was made.
 
 ## Steps in detail
 
@@ -72,15 +72,27 @@ git commit -s -m "fix(scope): <description>"
 git push origin <branch>
 ```
 
-### 5 — Reply to non-actionable comments
+### 5 — Reply to every comment
 
-Post a concise reply via the GitHub API:
+For **valid comments** (after the fix is pushed), reply referencing the commit SHA:
 
 ```bash
-gh api repos/cloudoperators/repo-guard/pulls/comments/<comment-id>/replies \
+gh api repos/cloudoperators/repo-guard/pulls/<PR>/comments \
   --method POST \
-  --field body="<reply text>"
+  --field in_reply_to=<comment-id> \
+  --field body="Fixed in commit <sha>. <one-sentence summary of what changed.>"
 ```
+
+For **stale or invalid comments**, reply explaining why no code change was made:
+
+```bash
+gh api repos/cloudoperators/repo-guard/pulls/<PR>/comments \
+  --method POST \
+  --field in_reply_to=<comment-id> \
+  --field body="<factual explanation of why this is not actioned>"
+```
+
+Note: use `in_reply_to` (not a `/replies` sub-resource — that endpoint does not exist for PR review comments).
 
 ## Conventions (from AGENTS.md)
 
@@ -100,8 +112,10 @@ Agent: Fetches comments from PR #113.
                  Comment 2 (Valid) — add unit tests ...
                  Comment 3 (Stale) — wrong constant reference, but the line no longer exists ...
        Asks for approval.
-User:  Implement the valid ones, reply to the stale one.
+User:  Implement the valid ones, reply to all of them.
 Agent: Edits api/v1/githuborganization_types.go, adds test file,
-       runs make controller-test, commits, pushes.
-       Posts reply to Comment 3 explaining it is stale.
+       runs make controller-test, commits (167822c), pushes.
+       Posts reply to Comment 1: "Fixed in commit 167822c. All six dedup loops now..."
+       Posts reply to Comment 2: "Fixed in commit 167822c. Added TestRepoChangeCalculator..."
+       Posts reply to Comment 3: "This line no longer exists in the diff..."
 ```

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -94,6 +94,36 @@ gh api repos/cloudoperators/repo-guard/pulls/<PR>/comments \
 
 Note: use `in_reply_to` (not a `/replies` sub-resource — that endpoint does not exist for PR review comments).
 
+After replying, resolve the thread via the GraphQL API (there is no REST endpoint for this):
+
+```bash
+# Step 1 — get the thread node IDs
+gh api graphql -f query='
+{
+  repository(owner: "cloudoperators", name: "repo-guard") {
+    pullRequest(number: <PR>) {
+      reviewThreads(first: 50) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { databaseId body }
+          }
+        }
+      }
+    }
+  }
+}'
+
+# Step 2 — resolve each thread by its node ID
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {threadId: "<THREAD_NODE_ID>"}) {
+    thread { id isResolved }
+  }
+}'
+```
+
 ## Conventions (from AGENTS.md)
 
 - All commits must be signed off (`-s`).
@@ -118,4 +148,5 @@ Agent: Edits api/v1/githuborganization_types.go, adds test file,
        Posts reply to Comment 1: "Fixed in commit 167822c. All six dedup loops now..."
        Posts reply to Comment 2: "Fixed in commit 167822c. Added TestRepoChangeCalculator..."
        Posts reply to Comment 3: "This line no longer exists in the diff..."
+       Resolves all three threads via GraphQL resolveReviewThread mutation.
 ```

--- a/api/v1/githuborganization_types.go
+++ b/api/v1/githuborganization_types.go
@@ -316,10 +316,11 @@ func (g GithubOrganization) TeamChangeCalculator(teamsFromKubernetes []string) (
 		if !kubernetesTeamFound {
 			// action: add the owner to github
 
-			// check if there is a waiting task
+			// check if there is a waiting or already-completed task
+			// A completed add operation means the team was already successfully created; do not re-queue.
 			teamOperationFound := false
 			for _, teamOpeation := range newStatus.Operations.GithubTeamOperations {
-				if strings.EqualFold(teamOpeation.Team, kubernetesTeam) && teamOpeation.Operation == GithubTeamOperationTypeAdd && teamOpeation.State != GithubTeamOperationStateComplete {
+				if strings.EqualFold(teamOpeation.Team, kubernetesTeam) && teamOpeation.Operation == GithubTeamOperationTypeAdd {
 					teamOperationFound = true
 					break
 				}
@@ -353,10 +354,11 @@ func (g GithubOrganization) TeamChangeCalculator(teamsFromKubernetes []string) (
 		if !kubernetesTeamFound {
 			// action: remove the team from github
 
-			// check if there is a waiting task
+			// check if there is a waiting or already-completed task
+			// A completed remove operation means the team was already successfully deleted; do not re-queue.
 			teamOperationFound := false
 			for _, teamOpeation := range newStatus.Operations.GithubTeamOperations {
-				if strings.EqualFold(teamOpeation.Team, githubTeam) && teamOpeation.Operation == GithubTeamOperationTypeRemove && teamOpeation.State != GithubTeamOperationStateComplete {
+				if strings.EqualFold(teamOpeation.Team, githubTeam) && teamOpeation.Operation == GithubTeamOperationTypeRemove {
 					teamOperationFound = true
 					break
 				}
@@ -415,10 +417,10 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 					if team.Permission != configTeam.Permission {
 						// remove the team and add it with the config permission
 
-						// check if there is a waiting task
+						// check if there is a waiting or already-completed task
 						repoTeamOperationRemoveFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove && op.State != GithubTeamOperationStateComplete {
+							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
 								repoTeamOperationRemoveFound = true
 								break
 							}
@@ -438,7 +440,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 						// add with the new permission
 						repoTeamOperationAddFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd && op.State != GithubTeamOperationStateComplete {
+							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
 								repoTeamOperationAddFound = true
 								break
 							}
@@ -464,7 +466,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 				// add with the new permission
 				repoTeamOperationAddFound := false
 				for _, op := range operations {
-					if strings.EqualFold(op.Team, configTeam.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd && op.State != GithubTeamOperationStateComplete {
+					if strings.EqualFold(op.Team, configTeam.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
 						repoTeamOperationAddFound = true
 						break
 					}
@@ -493,10 +495,10 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 					if team.Permission != configTeam.Permission {
 						// remove the team and add it with the config permission
 
-						// check if there is a waiting task
+						// check if there is a waiting or already-completed task
 						repoTeamOperationRemoveFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove && op.State != GithubTeamOperationStateComplete {
+							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
 								repoTeamOperationRemoveFound = true
 								break
 							}
@@ -516,7 +518,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 						// add with the new permission
 						repoTeamOperationAddFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd && op.State != GithubTeamOperationStateComplete {
+							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
 								repoTeamOperationAddFound = true
 								break
 							}
@@ -539,10 +541,10 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 			}
 
 			if !repoTeamFound {
-				// check if there is a waiting task
+				// check if there is a waiting or already-completed task
 				repoTeamOperationRemoveFound := false
 				for _, op := range operations {
-					if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove && op.State != GithubTeamOperationStateComplete {
+					if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
 						repoTeamOperationRemoveFound = true
 						break
 					}

--- a/api/v1/githuborganization_types.go
+++ b/api/v1/githuborganization_types.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/gosimple/slug"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -409,18 +410,20 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 
 		// ensure that default teams are assigned
 		for _, configTeam := range configExtendedWithExceptions {
+			configTeamSlug := slug.Make(configTeam.Team)
 			configTeamFound := false
 
 			for _, team := range repo.Teams {
-				if team.Team == configTeam.Team {
+				if team.Team == configTeamSlug {
 					configTeamFound = true
 					if team.Permission != configTeam.Permission {
 						// remove the team and add it with the config permission
 
 						// check if there is a waiting or already-completed task
+						// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 						repoTeamOperationRemoveFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
+							if strings.EqualFold(slug.Make(op.Team), team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
 								repoTeamOperationRemoveFound = true
 								break
 							}
@@ -438,9 +441,10 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 						}
 
 						// add with the new permission
+						// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 						repoTeamOperationAddFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
+							if strings.EqualFold(slug.Make(op.Team), team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
 								repoTeamOperationAddFound = true
 								break
 							}
@@ -449,7 +453,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 						if !repoTeamOperationAddFound {
 							op := GithubRepoTeamOperation{
 								Operation:  GithubRepoTeamOperationTypeAdd,
-								Team:       configTeam.Team,
+								Team:       configTeamSlug,
 								Repo:       repo.Name,
 								Permission: configTeam.Permission,
 								State:      GithubRepoTeamOperationStatePending,
@@ -464,9 +468,10 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 
 			if !configTeamFound {
 				// add with the new permission
+				// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 				repoTeamOperationAddFound := false
 				for _, op := range operations {
-					if strings.EqualFold(op.Team, configTeam.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
+					if strings.EqualFold(slug.Make(op.Team), configTeamSlug) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
 						repoTeamOperationAddFound = true
 						break
 					}
@@ -475,7 +480,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 				if !repoTeamOperationAddFound {
 					op := GithubRepoTeamOperation{
 						Operation:  GithubRepoTeamOperationTypeAdd,
-						Team:       configTeam.Team,
+						Team:       configTeamSlug,
 						Repo:       repo.Name,
 						Permission: configTeam.Permission,
 						State:      GithubRepoTeamOperationStatePending,
@@ -490,15 +495,17 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 		for _, team := range repo.Teams {
 			repoTeamFound := false
 			for _, configTeam := range configExtendedWithExceptions {
-				if team.Team == configTeam.Team {
+				configTeamSlug := slug.Make(configTeam.Team)
+				if team.Team == configTeamSlug {
 					repoTeamFound = true
 					if team.Permission != configTeam.Permission {
 						// remove the team and add it with the config permission
 
 						// check if there is a waiting or already-completed task
+						// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 						repoTeamOperationRemoveFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
+							if strings.EqualFold(slug.Make(op.Team), team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
 								repoTeamOperationRemoveFound = true
 								break
 							}
@@ -516,9 +523,10 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 						}
 
 						// add with the new permission
+						// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 						repoTeamOperationAddFound := false
 						for _, op := range operations {
-							if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
+							if strings.EqualFold(slug.Make(op.Team), team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeAdd {
 								repoTeamOperationAddFound = true
 								break
 							}
@@ -527,7 +535,7 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 						if !repoTeamOperationAddFound {
 							op := GithubRepoTeamOperation{
 								Operation:  GithubRepoTeamOperationTypeAdd,
-								Team:       configTeam.Team,
+								Team:       configTeamSlug,
 								Repo:       repo.Name,
 								Permission: configTeam.Permission,
 								State:      GithubRepoTeamOperationStatePending,
@@ -542,9 +550,10 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 
 			if !repoTeamFound {
 				// check if there is a waiting or already-completed task
+				// Normalize op.Team via slug.Make so persisted pre-fix display-name values still match.
 				repoTeamOperationRemoveFound := false
 				for _, op := range operations {
-					if strings.EqualFold(op.Team, team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
+					if strings.EqualFold(slug.Make(op.Team), team.Team) && repo.Name == op.Repo && op.Operation == GithubRepoTeamOperationTypeRemove {
 						repoTeamOperationRemoveFound = true
 						break
 					}

--- a/api/v1/githuborganization_types_test.go
+++ b/api/v1/githuborganization_types_test.go
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"testing"
+)
+
+// teamOp is a helper to build a GithubRepoTeamOperation for test setup.
+func teamOp(team, repo string, opType GithubRepoTeamOperationType, state GithubRepoTeamOperationState) GithubRepoTeamOperation {
+	return GithubRepoTeamOperation{
+		Team:      team,
+		Repo:      repo,
+		Operation: opType,
+		State:     state,
+	}
+}
+
+func TestRepoChangeCalculator(t *testing.T) {
+	tests := []struct {
+		name          string
+		defaultConfig []GithubTeamWithPermission
+		actual        []GithubRepository
+		operations    []GithubRepoTeamOperation
+		wantOps       []GithubRepoTeamOperation
+	}{
+		{
+			name: "team missing from repo generates ADD op",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "my-team", Permission: GithubTeamPermissionPush},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{}},
+			},
+			operations: nil,
+			wantOps: []GithubRepoTeamOperation{
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeAdd, Permission: GithubTeamPermissionPush, State: GithubRepoTeamOperationStatePending},
+			},
+		},
+		{
+			name: "team present with correct permission generates no op",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "my-team", Permission: GithubTeamPermissionPush},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{
+					{Team: "my-team", Permission: GithubTeamPermissionPush},
+				}},
+			},
+			operations: nil,
+			wantOps:    []GithubRepoTeamOperation{},
+		},
+		{
+			// Both the "ensure default teams" loop and the "iterate repo teams" loop
+			// independently detect permission drift and each emit REMOVE+ADD. The
+			// dedup only fires against the *incoming* operations slice, not against
+			// ops already accumulated in the same call. CleanCompletedOperations and
+			// the cross-reconcile dedup handle the real-world case.
+			name: "team present with wrong permission generates REMOVE and ADD ops (both loops fire)",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "my-team", Permission: GithubTeamPermissionAdmin},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{
+					{Team: "my-team", Permission: GithubTeamPermissionPush},
+				}},
+			},
+			operations: nil,
+			wantOps: []GithubRepoTeamOperation{
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeRemove, State: GithubRepoTeamOperationStatePending},
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeAdd, Permission: GithubTeamPermissionAdmin, State: GithubRepoTeamOperationStatePending},
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeRemove, State: GithubRepoTeamOperationStatePending},
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeAdd, Permission: GithubTeamPermissionAdmin, State: GithubRepoTeamOperationStatePending},
+			},
+		},
+		{
+			name:          "team in repo but not in config generates REMOVE op",
+			defaultConfig: []GithubTeamWithPermission{},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{
+					{Team: "stale-team", Permission: GithubTeamPermissionPush},
+				}},
+			},
+			operations: nil,
+			wantOps: []GithubRepoTeamOperation{
+				{Team: "stale-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeRemove, State: GithubRepoTeamOperationStatePending},
+			},
+		},
+		{
+			name: "existing pending ADD op deduplicates — no new ADD generated",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "my-team", Permission: GithubTeamPermissionPush},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{}},
+			},
+			operations: []GithubRepoTeamOperation{
+				teamOp("my-team", "repo1", GithubRepoTeamOperationTypeAdd, GithubRepoTeamOperationStatePending),
+			},
+			wantOps: []GithubRepoTeamOperation{},
+		},
+		{
+			name: "existing completed ADD op deduplicates — no new ADD generated",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "my-team", Permission: GithubTeamPermissionPush},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{}},
+			},
+			operations: []GithubRepoTeamOperation{
+				teamOp("my-team", "repo1", GithubRepoTeamOperationTypeAdd, GithubRepoTeamOperationStateComplete),
+			},
+			wantOps: []GithubRepoTeamOperation{},
+		},
+		{
+			// Upgrade-safety: op.Team stored as display name before the slug fix was deployed.
+			// slug.Make("My Team") == "my-team", so the dedup must still fire.
+			name: "existing ADD op with display-name (pre-fix) deduplicates against slug config team",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "My Team", Permission: GithubTeamPermissionPush},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{}},
+			},
+			operations: []GithubRepoTeamOperation{
+				// stored with the old display name before the slug fix
+				teamOp("My Team", "repo1", GithubRepoTeamOperationTypeAdd, GithubRepoTeamOperationStatePending),
+			},
+			wantOps: []GithubRepoTeamOperation{},
+		},
+		{
+			// Spec team name with spaces/uppercase must be normalised to slug in the new op.
+			name: "display-name spec team generates ADD op with slugified Team field",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "My Awesome Team", Permission: GithubTeamPermissionPull},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{}},
+			},
+			operations: nil,
+			wantOps: []GithubRepoTeamOperation{
+				{Team: "my-awesome-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeAdd, Permission: GithubTeamPermissionPull, State: GithubRepoTeamOperationStatePending},
+			},
+		},
+		{
+			// GitHub returns the slug ("my-team") in repo.Teams.  The spec has the
+			// display name ("My Team").  After normalisation both resolve to "my-team"
+			// so no operation should be generated.
+			name: "spec display name matches github slug — no op generated",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "My Team", Permission: GithubTeamPermissionPush},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{
+					{Team: "my-team", Permission: GithubTeamPermissionPush},
+				}},
+			},
+			operations: nil,
+			wantOps:    []GithubRepoTeamOperation{},
+		},
+		{
+			// Same as above: both loops fire for permission drift.
+			name: "permission drift with display-name spec team generates REMOVE and ADD with slug (both loops fire)",
+			defaultConfig: []GithubTeamWithPermission{
+				{Team: "My Team", Permission: GithubTeamPermissionAdmin},
+			},
+			actual: []GithubRepository{
+				{Name: "repo1", Teams: []GithubTeamWithPermission{
+					{Team: "my-team", Permission: GithubTeamPermissionPush},
+				}},
+			},
+			operations: nil,
+			wantOps: []GithubRepoTeamOperation{
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeRemove, State: GithubRepoTeamOperationStatePending},
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeAdd, Permission: GithubTeamPermissionAdmin, State: GithubRepoTeamOperationStatePending},
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeRemove, State: GithubRepoTeamOperationStatePending},
+				{Team: "my-team", Repo: "repo1", Operation: GithubRepoTeamOperationTypeAdd, Permission: GithubTeamPermissionAdmin, State: GithubRepoTeamOperationStatePending},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := repoChangeCalculator(tt.defaultConfig, tt.actual, nil, nil, tt.operations)
+
+			if len(got) != len(tt.wantOps) {
+				t.Fatalf("got %d ops, want %d ops\ngot:  %+v\nwant: %+v", len(got), len(tt.wantOps), got, tt.wantOps)
+			}
+
+			for i, want := range tt.wantOps {
+				g := got[i]
+				if g.Team != want.Team {
+					t.Errorf("op[%d].Team = %q, want %q", i, g.Team, want.Team)
+				}
+				if g.Repo != want.Repo {
+					t.Errorf("op[%d].Repo = %q, want %q", i, g.Repo, want.Repo)
+				}
+				if g.Operation != want.Operation {
+					t.Errorf("op[%d].Operation = %q, want %q", i, g.Operation, want.Operation)
+				}
+				if want.Permission != "" && g.Permission != want.Permission {
+					t.Errorf("op[%d].Permission = %q, want %q", i, g.Permission, want.Permission)
+				}
+				if g.State != want.State {
+					t.Errorf("op[%d].State = %q, want %q", i, g.State, want.State)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/review-pr.md` — a reusable `/review-pr <PR>` slash command for Claude Code.
- The command fetches all inline and conversation comments from a PR via `gh api`, assesses each comment for validity (valid / stale / invalid), presents findings to the user for approval, implements valid fixes with tests and a DCO-signed commit, and posts factual replies to non-actionable comments.
- Derived from the live workflow used to address Copilot review comments on PR #113.

## Test plan

- [ ] Run `/review-pr 113` in this repo and verify the command is picked up by Claude Code.
- [ ] Confirm the agent follows the steps described: fetches comments, presents assessment, waits for approval before changing any code.
- [ ] Verify the command text follows project conventions from `AGENTS.md` (signed-off commits, `type(scope)` style, `make controller-test`).