### PR TITLE
chore: rename renovate-merge command to dependabot-merge

### DIFF
--- a/.claude/commands/dependabot-merge.md
+++ b/.claude/commands/dependabot-merge.md
@@ -1,0 +1,108 @@
+    # Dependabot Merge
+
+Review open Dependabot PRs in this repository, summarize the changes, ask for approval, wait for all CI checks to pass, then merge the approved PRs.
+
+## Steps
+
+1. **List open Dependabot PRs**
+
+Run the following to list PRs ordered by size label from smallest to largest (XS → S → M → L → XL):
+```bash
+gh pr list --state open --author "dependabot[bot]" --repo cloudoperators/repo-guard --json number,title,labels,headRefName,createdAt | \
+  jq 'def size_order: . as $l | ["XS","S","M","L","XL"] | index($l) // 99;
+  sort_by(.labels | map(.name | select(startswith("size/"))) | first | ltrimstr("size/") | size_order) |
+  .[] | [(.number | tostring), .title, (.labels | map(.name) | join(", ")), .headRefName] | @tsv'
+```
+
+If there are no open Dependabot PRs, report that and stop.
+
+2. **Review and summarize each PR**
+
+For each open PR, fetch its details:
+```
+gh pr view <PR_NUMBER> --repo cloudoperators/repo-guard
+```
+
+Also fetch the diff to understand what changed:
+```
+gh pr diff <PR_NUMBER> --repo cloudoperators/repo-guard
+```
+
+Group the PRs by category (e.g. Go modules, GitHub Actions, tooling/lint, Kubernetes packages, Flux packages, major upgrades) and present a concise summary table with:
+- PR number and title
+- What is being updated (dependency name, old version → new version)
+- Category (patch / minor / major)
+- Any notable risks (e.g. major version bumps, breaking changes)
+
+3. **Ask which PRs to process**
+
+Ask the user which PRs they want to merge. Present the list and wait for the user to confirm specific PR numbers or say "all".
+
+4. **For each selected PR: show diff, ask for confirmation, update if needed, wait for checks, then merge**
+
+Process each PR one at a time in the following order:
+
+**a) Show the diff and ask for confirmation**
+
+Fetch and display the diff for the PR:
+```bash
+gh pr diff <PR_NUMBER> --repo cloudoperators/repo-guard
+```
+
+Present a concise summary of what changed (files modified, version bumps) and explicitly ask the user: "Do you want to approve and merge PR #<PR_NUMBER>?" Wait for the user to respond before proceeding.
+
+- If the user says **"approve"** (or yes/merge): approve the PR and enable auto-merge (see steps b and c below).
+- If the user says **"skip"** (or no/decline): skip to the next PR.
+
+**b) Check if the PR needs updating (rebasing)**
+
+```bash
+gh pr view <PR_NUMBER> --repo cloudoperators/repo-guard --json mergeStateStatus,mergeable
+```
+
+If `mergeStateStatus` is `BEHIND` or `mergeable` is `CONFLICTING`, rebase the PR against the base branch by posting a rebase comment:
+```bash
+gh pr comment <PR_NUMBER> --repo cloudoperators/repo-guard --body "@dependabot rebase"
+```
+Then wait 30 seconds and poll until the PR is no longer behind before continuing.
+
+**c) Approve the PR and enable auto-merge**
+
+First, approve the PR:
+```bash
+gh pr review <PR_NUMBER> --repo cloudoperators/repo-guard --approve
+```
+
+Then enable auto-merge so the PR merges automatically once all branch protection requirements are satisfied:
+```bash
+gh pr merge <PR_NUMBER> --repo cloudoperators/repo-guard --squash --auto
+```
+
+Then poll CI checks every 60 seconds to monitor progress. Report the final status once all checks reach a terminal state (`pass`, `skipping`, or `fail`):
+
+```bash
+while true; do
+  STATUS=$(gh pr checks <PR_NUMBER> --repo cloudoperators/repo-guard 2>&1)
+  PENDING=$(echo "$STATUS" | grep -cE "pending|in_progress" || true)
+  FAILING=$(echo "$STATUS" | grep -cE "^[^\t]+\tfail" || true)
+  echo "[$(date '+%H:%M:%S')] PR #<PR_NUMBER> — Pending/In-progress: $PENDING, Failing: $FAILING"
+  if [ "$PENDING" -eq 0 ] && [ "$FAILING" -eq 0 ]; then
+    echo "All checks passed — PR #<PR_NUMBER> will be merged automatically."
+    break
+  elif [ "$PENDING" -eq 0 ] && [ "$FAILING" -gt 0 ]; then
+    echo "Some checks failed on PR #<PR_NUMBER>. Auto-merge will be blocked."
+    echo "$STATUS" | grep -E "^[^\t]+\tfail"
+    break
+  fi
+  sleep 60
+done
+```
+
+If a PR has failing checks, report which checks failed.
+
+5. **Final report**
+
+After processing all approved PRs, summarize:
+- Which PRs were successfully merged
+- Which PRs were skipped due to failing checks
+- Any PRs that were not approved by the user


### PR DESCRIPTION
## Summary

- Renames `.claude/commands/renovate-merge.md` to `.claude/commands/dependabot-merge.md` to align the command name with the actual tool used (Dependabot).

## Test plan

- [ ] No code changes; verify the renamed file is present and the old name is gone.