### PR TITLE
fix(github): treat 404 from ListPendingOrgInvitations as no pending invitations

### DIFF
--- a/internal/github/organizations.go
+++ b/internal/github/organizations.go
@@ -136,6 +136,11 @@ func (o *DefaultOrganizationProvider) pendingAdminMembers(ctx context.Context) (
 	for {
 		invitations, resp, err := o.organizationService.ListPendingOrgInvitations(ctx, o.organization, opt)
 		if err != nil {
+			// Some GitHub Enterprise instances do not expose the invitations endpoint; treat
+			// 404 as "no pending invitations" so reconciliation is not blocked.
+			if resp != nil && resp.StatusCode == 404 {
+				return result, nil
+			}
 			return nil, err
 		}
 		for _, inv := range invitations {

--- a/internal/github/organizations_test.go
+++ b/internal/github/organizations_test.go
@@ -84,7 +84,7 @@ func TestPendingAdminMembers_PropagatesNon404Error(t *testing.T) {
 
 	mux.HandleFunc("/api/v3/orgs/test-org/invitations", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintln(w, `{"message":"Internal Server Error"}`)
+		_, _ = fmt.Fprintln(w, `{"message":"Internal Server Error"}`)
 	})
 
 	_, err := provider.pendingAdminMembers(t.Context())

--- a/internal/github/organizations_test.go
+++ b/internal/github/organizations_test.go
@@ -40,7 +40,7 @@ func TestPendingAdminMembers_404TreatedAsEmpty(t *testing.T) {
 
 	mux.HandleFunc("/api/v3/orgs/test-org/invitations", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintln(w, `{"message":"Not Found"}`)
+		_, _ = fmt.Fprintln(w, `{"message":"Not Found"}`)
 	})
 
 	members, err := provider.pendingAdminMembers(t.Context())
@@ -57,14 +57,14 @@ func TestPendingAdminMembers_ReturnsAdminInvitees(t *testing.T) {
 
 	mux.HandleFunc("/api/v3/orgs/test-org/invitations", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintln(w, `[
+		_, _ = fmt.Fprintln(w, `[
 			{"login": "alice", "role": "admin"},
 			{"login": "bob",   "role": "member"}
 		]`)
 	})
 	mux.HandleFunc("/api/v3/users/alice", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintln(w, `{"login": "alice", "id": 42}`)
+		_, _ = fmt.Fprintln(w, `{"login": "alice", "id": 42}`)
 	})
 
 	members, err := provider.pendingAdminMembers(t.Context())

--- a/internal/github/organizations_test.go
+++ b/internal/github/organizations_test.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gogithub "github.com/google/go-github/v85/github"
+)
+
+// newTestOrganizationProvider creates a DefaultOrganizationProvider backed by a
+// fake HTTP server. The caller receives both the provider and the mux to
+// register route handlers before calling provider methods.
+func newTestOrganizationProvider(t *testing.T) (*DefaultOrganizationProvider, *http.ServeMux) {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	httpClient := srv.Client()
+	client, err := gogithub.NewClient(httpClient).WithAuthToken("test-token").WithEnterpriseURLs(srv.URL+"/", srv.URL+"/")
+	if err != nil {
+		t.Fatalf("create github client: %v", err)
+	}
+
+	provider := &DefaultOrganizationProvider{
+		organizationService: *client.Organizations,
+		usersService:        *client.Users,
+		organization:        "test-org",
+	}
+	return provider, mux
+}
+
+func TestPendingAdminMembers_404TreatedAsEmpty(t *testing.T) {
+	provider, mux := newTestOrganizationProvider(t)
+
+	mux.HandleFunc("/api/v3/orgs/test-org/invitations", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintln(w, `{"message":"Not Found"}`)
+	})
+
+	members, err := provider.pendingAdminMembers(t.Context())
+	if err != nil {
+		t.Fatalf("expected no error for 404, got: %v", err)
+	}
+	if len(members) != 0 {
+		t.Errorf("expected empty members for 404, got %d", len(members))
+	}
+}
+
+func TestPendingAdminMembers_ReturnsAdminInvitees(t *testing.T) {
+	provider, mux := newTestOrganizationProvider(t)
+
+	mux.HandleFunc("/api/v3/orgs/test-org/invitations", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `[
+			{"login": "alice", "role": "admin"},
+			{"login": "bob",   "role": "member"}
+		]`)
+	})
+	mux.HandleFunc("/api/v3/users/alice", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"login": "alice", "id": 42}`)
+	})
+
+	members, err := provider.pendingAdminMembers(t.Context())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(members) != 1 {
+		t.Fatalf("expected 1 admin invitee, got %d", len(members))
+	}
+	if members[0].Login != "alice" || members[0].UID != 42 {
+		t.Errorf("unexpected member: %+v", members[0])
+	}
+}
+
+func TestPendingAdminMembers_PropagatesNon404Error(t *testing.T) {
+	provider, mux := newTestOrganizationProvider(t)
+
+	mux.HandleFunc("/api/v3/orgs/test-org/invitations", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, `{"message":"Internal Server Error"}`)
+	})
+
+	_, err := provider.pendingAdminMembers(t.Context())
+	if err == nil {
+		t.Fatal("expected error for 500, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Some GitHub Enterprise instances (confirmed on GHE 3.17.14) do not expose `GET /orgs/{org}/invitations`, returning 404 regardless of app permissions — even with `Members: Read and write` granted to the GitHub App.
- Previously this caused every reconcile of `GithubOrganization` to fail with `error in getting organization owners from github`, leaving affected orgs permanently stuck in `failed` state.
- Fix: treat a 404 from `ListPendingOrgInvitations` as an empty pending-invitations list. All other errors continue to propagate.

## Test plan

- [ ] `go test ./internal/github/` passes (3 new unit tests: 404→empty, happy path with admin-role filter, non-404 error propagation)
- [ ] Redeploy controller against affected orgs (`tools--cloudoperators`, `tools--cerebro-cc`, `wdf--plusone`, etc.) and verify they no longer log `error in getting organization owners from github`