### PR TITLE
fix(controller): evaluate TTLs per-operation against own timestamp

### DIFF
--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -145,6 +145,10 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 			if ttlStr == "" {
 				return
 			}
+			if _, err := time.ParseDuration(ttlStr); err != nil {
+				l.Info("invalid TTL duration label; skipping cleanup", "label", label, "value", ttlStr, "error", err)
+				return
+			}
 			if updated, changed := applyUserOpsTTL(l, newStatus.Operations.OrganizationOwnerOperations, ttlStr, userState, label, now); changed {
 				newStatus.Operations.OrganizationOwnerOperations = updated
 				anyChanged = true
@@ -168,12 +172,17 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 			applyBucket(completedTTL, GITHUB_ORG_LABEL_COMPLETED_TTL, v1.GithubUserOperationStateComplete, v1.GithubRepoTeamOperationStateComplete)
 		}
 
-		// failedTTL: also clear org-level error if no failed ops remain.
+		// failedTTL: also clear org-level error once failed ops have been cleaned
+		// up by TTL. Only clear when failed ops were present in the original status
+		// (so spec/config/API errors unrelated to ops are not wiped).
 		clearOrgError := false
 		if failedTTL != "" && githubOrganization.Status.OrganizationStatusError != "" {
-			stillFailed := (&v1.GithubOrganization{Status: newStatus}).FailedOperationsFound()
-			if !stillFailed {
-				clearOrgError = true
+			hadFailed := (&v1.GithubOrganization{Status: githubOrganization.Status}).FailedOperationsFound()
+			if hadFailed {
+				stillFailed := (&v1.GithubOrganization{Status: newStatus}).FailedOperationsFound()
+				if !stillFailed {
+					clearOrgError = true
+				}
 			}
 		}
 

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -130,80 +130,83 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}
 
-	// TTL-based maintenance to keep status small and healthy
+	// TTL-based maintenance to keep status small and healthy.
+	// TTLs are evaluated per-operation against each op's own Timestamp so that
+	// later activity on the organization does not indefinitely shield aged ops
+	// from cleanup.
 	if githubOrganization.Labels != nil {
-		// Clear failed operations and failed status after TTL
-		if ttlStr, ok := githubOrganization.Labels[GITHUB_ORG_LABEL_FAILED_TTL]; ok && ttlStr != "" {
-			if githubOrganization.Status.OrganizationStatus == v1.GithubOrganizationStateFailed && !githubOrganization.Status.OrganizationStatusTimestamp.IsZero() {
-				if expired, err := ttlExpired(ttlStr, githubOrganization.Status.OrganizationStatusTimestamp.Time, time.Now()); err != nil {
-					l.Info("invalid failedTTL duration label; skipping cleanup", "label", GITHUB_ORG_LABEL_FAILED_TTL, "value", ttlStr, "error", err.Error())
-				} else if expired {
-					l.Info("failed TTL expired: cleaning failed operations and status error")
-					newStatus, changed := githubOrganization.CleanFailedOperations()
-					if changed || githubOrganization.Status.OrganizationStatusError != "" {
-						// reset error and recompute top-level state
-						newStatus.OrganizationStatusError = ""
-						if (&v1.GithubOrganization{Status: newStatus}).PendingOperationsFound() {
-							newStatus.OrganizationStatus = v1.GithubOrganizationStatePendingOperations
-						} else if (&v1.GithubOrganization{Status: newStatus}).FailedOperationsFound() {
-							newStatus.OrganizationStatus = v1.GithubOrganizationStateFailed
-						} else {
-							newStatus.OrganizationStatus = v1.GithubOrganizationStateComplete
-						}
-						newStatus.OrganizationStatusTimestamp = metav1.Now()
-						githubOrganization.Status = newStatus
-						err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-							latest := &v1.GithubOrganization{}
-							if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
-								return err
-							}
-							latest.Status = newStatus
-							return r.Client.Status().Update(ctx, latest)
-						})
-						if err != nil {
-							return reconcile.Result{}, err
-						}
-						// (defer will also update it at the end)
-						return reconcile.Result{}, nil
-					}
-				}
+		now := time.Now()
+
+		// Stage cleanup over both TTL buckets in a single status write.
+		newStatus := *githubOrganization.Status.DeepCopy()
+		anyChanged := false
+
+		applyBucket := func(ttlStr, label string, userState v1.GithubUserOperationState, repoState v1.GithubRepoTeamOperationState) {
+			if ttlStr == "" {
+				return
+			}
+			if updated, changed := applyUserOpsTTL(l, newStatus.Operations.OrganizationOwnerOperations, ttlStr, userState, label, now); changed {
+				newStatus.Operations.OrganizationOwnerOperations = updated
+				anyChanged = true
+			}
+			if updated, changed := applyRepoOpsTTL(l, newStatus.Operations.RepositoryTeamOperations, ttlStr, repoState, label, now); changed {
+				newStatus.Operations.RepositoryTeamOperations = updated
+				anyChanged = true
+			}
+			if updated, changed := applyTeamOpsTTL(l, newStatus.Operations.GithubTeamOperations, ttlStr, userState, label, now); changed {
+				newStatus.Operations.GithubTeamOperations = updated
+				anyChanged = true
 			}
 		}
-		// Clear completed operations after TTL
-		if ttlStr, ok := githubOrganization.Labels[GITHUB_ORG_LABEL_COMPLETED_TTL]; ok && ttlStr != "" {
-			if !githubOrganization.Status.OrganizationStatusTimestamp.IsZero() {
-				if expired, err := ttlExpired(ttlStr, githubOrganization.Status.OrganizationStatusTimestamp.Time, time.Now()); err != nil {
-					l.Info("invalid completedTTL duration label; skipping cleanup", "label", GITHUB_ORG_LABEL_COMPLETED_TTL, "value", ttlStr, "error", err.Error())
-				} else if expired {
-					l.Info("completed TTL expired: cleaning completed operations")
-					newStatus, changed := githubOrganization.CleanCompletedOperations()
-					if changed {
-						// keep current orgStatus if still pending/failed, otherwise mark complete
-						if (&v1.GithubOrganization{Status: newStatus}).PendingOperationsFound() {
-							newStatus.OrganizationStatus = v1.GithubOrganizationStatePendingOperations
-						} else if (&v1.GithubOrganization{Status: newStatus}).FailedOperationsFound() {
-							newStatus.OrganizationStatus = v1.GithubOrganizationStateFailed
-						} else {
-							newStatus.OrganizationStatus = v1.GithubOrganizationStateComplete
-						}
-						newStatus.OrganizationStatusTimestamp = metav1.Now()
-						githubOrganization.Status = newStatus
-						err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-							latest := &v1.GithubOrganization{}
-							if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
-								return err
-							}
-							latest.Status = newStatus
-							return r.Client.Status().Update(ctx, latest)
-						})
-						if err != nil {
-							return reconcile.Result{}, err
-						}
-						// (defer will also update it at the end)
-						return reconcile.Result{}, nil
-					}
-				}
+
+		failedTTL := githubOrganization.Labels[GITHUB_ORG_LABEL_FAILED_TTL]
+		completedTTL := githubOrganization.Labels[GITHUB_ORG_LABEL_COMPLETED_TTL]
+		if failedTTL != "" {
+			applyBucket(failedTTL, GITHUB_ORG_LABEL_FAILED_TTL, v1.GithubUserOperationStateFailed, v1.GithubRepoTeamOperationStateFailed)
+		}
+		if completedTTL != "" {
+			applyBucket(completedTTL, GITHUB_ORG_LABEL_COMPLETED_TTL, v1.GithubUserOperationStateComplete, v1.GithubRepoTeamOperationStateComplete)
+		}
+
+		// failedTTL: also clear org-level error if no failed ops remain.
+		clearOrgError := false
+		if failedTTL != "" && githubOrganization.Status.OrganizationStatusError != "" {
+			stillFailed := (&v1.GithubOrganization{Status: newStatus}).FailedOperationsFound()
+			if !stillFailed {
+				clearOrgError = true
 			}
+		}
+
+		if anyChanged || clearOrgError {
+			if anyChanged {
+				l.Info("TTL expired: cleaned aged operations", "failedTTL", failedTTL, "completedTTL", completedTTL)
+			}
+			if clearOrgError {
+				newStatus.OrganizationStatusError = ""
+			}
+			temp := &v1.GithubOrganization{Status: newStatus}
+			switch {
+			case temp.PendingOperationsFound():
+				newStatus.OrganizationStatus = v1.GithubOrganizationStatePendingOperations
+			case temp.FailedOperationsFound():
+				newStatus.OrganizationStatus = v1.GithubOrganizationStateFailed
+			default:
+				newStatus.OrganizationStatus = v1.GithubOrganizationStateComplete
+			}
+			newStatus.OrganizationStatusTimestamp = metav1.Now()
+			githubOrganization.Status = newStatus
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				latest := &v1.GithubOrganization{}
+				if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
+					return err
+				}
+				latest.Status = newStatus
+				return r.Client.Status().Update(ctx, latest)
+			})
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+			return reconcile.Result{}, nil
 		}
 	}
 

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -145,19 +145,20 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 			if ttlStr == "" {
 				return
 			}
-			if _, err := time.ParseDuration(ttlStr); err != nil {
+			ttl, err := time.ParseDuration(ttlStr)
+			if err != nil {
 				l.Info("invalid TTL duration label; skipping cleanup", "label", label, "value", ttlStr, "error", err)
 				return
 			}
-			if updated, changed := applyUserOpsTTL(l, newStatus.Operations.OrganizationOwnerOperations, ttlStr, userState, label, now); changed {
+			if updated, changed := applyUserOpsTTL(newStatus.Operations.OrganizationOwnerOperations, ttl, userState, now); changed {
 				newStatus.Operations.OrganizationOwnerOperations = updated
 				anyChanged = true
 			}
-			if updated, changed := applyRepoOpsTTL(l, newStatus.Operations.RepositoryTeamOperations, ttlStr, repoState, label, now); changed {
+			if updated, changed := applyRepoOpsTTL(newStatus.Operations.RepositoryTeamOperations, ttl, repoState, now); changed {
 				newStatus.Operations.RepositoryTeamOperations = updated
 				anyChanged = true
 			}
-			if updated, changed := applyTeamOpsTTL(l, newStatus.Operations.GithubTeamOperations, ttlStr, userState, label, now); changed {
+			if updated, changed := applyTeamOpsTTL(newStatus.Operations.GithubTeamOperations, ttl, userState, now); changed {
 				newStatus.Operations.GithubTeamOperations = updated
 				anyChanged = true
 			}

--- a/internal/controller/githuborganization_ttl_test.go
+++ b/internal/controller/githuborganization_ttl_test.go
@@ -120,4 +120,5 @@ var _ = Describe("GithubOrganization TTL labels maintenance", Ordered, func() {
 				len(cur.Status.Operations.OrganizationOwnerOperations)
 		}, 3*timeout, interval).Should(Equal(0))
 	})
+
 })

--- a/internal/controller/githuborganization_ttl_test.go
+++ b/internal/controller/githuborganization_ttl_test.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	repoguardsapv1 "github.com/cloudoperators/repo-guard/api/v1"
 	. "github.com/onsi/ginkgo/v2"
@@ -119,6 +120,90 @@ var _ = Describe("GithubOrganization TTL labels maintenance", Ordered, func() {
 				len(cur.Status.Operations.GithubTeamOperations) +
 				len(cur.Status.Operations.OrganizationOwnerOperations)
 		}, 3*timeout, interval).Should(Equal(0))
+	})
+
+	It("preserves operations when failedTTL label has an invalid duration value", func() {
+		ctx := context.Background()
+
+		org := githubOrganizationGreenhouseSandboxForTTLTests.DeepCopy()
+		org.Name = generateUniqueName("ttl-invalid")
+		org.Spec.Github = github.Name
+		if org.Labels == nil {
+			org.Labels = map[string]string{}
+		}
+		org.Labels[GITHUB_ORG_LABEL_FAILED_TTL] = "not-a-duration"
+
+		Expect(ensureResourceCreated(ctx, org)).To(Succeed())
+		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, org) })
+
+		Expect(updateStatusWithRetry(ctx, k8sClient, &repoguardsapv1.GithubOrganization{
+			ObjectMeta: metav1.ObjectMeta{Name: org.Name, Namespace: org.Namespace},
+		}, func(cur *repoguardsapv1.GithubOrganization) {
+			cur.Status = repoguardsapv1.GithubOrganizationStatus{
+				OrganizationStatus:      repoguardsapv1.GithubOrganizationStateFailed,
+				OrganizationStatusError: "some failure",
+				Operations: repoguardsapv1.GithubOrganizationStatusOperations{
+					OrganizationOwnerOperations: []repoguardsapv1.GithubUserOperation{{
+						User:      "u1",
+						State:     repoguardsapv1.GithubUserOperationStateFailed,
+						Timestamp: metav1.NewTime(time.Now().Add(-48 * time.Hour)),
+					}},
+				},
+			}
+		})).To(Succeed())
+
+		totalOps := func() int {
+			cur := &repoguardsapv1.GithubOrganization{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: org.Namespace, Name: org.Name}, cur); err != nil {
+				return -1
+			}
+			return len(cur.Status.Operations.OrganizationOwnerOperations) +
+				len(cur.Status.Operations.RepositoryTeamOperations) +
+				len(cur.Status.Operations.GithubTeamOperations)
+		}
+		Consistently(totalOps, 5*time.Second, interval).Should(Equal(1))
+	})
+
+	It("preserves operations when failedTTL label is empty", func() {
+		ctx := context.Background()
+
+		org := githubOrganizationGreenhouseSandboxForTTLTests.DeepCopy()
+		org.Name = generateUniqueName("ttl-empty")
+		org.Spec.Github = github.Name
+		if org.Labels == nil {
+			org.Labels = map[string]string{}
+		}
+		org.Labels[GITHUB_ORG_LABEL_FAILED_TTL] = ""
+
+		Expect(ensureResourceCreated(ctx, org)).To(Succeed())
+		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, org) })
+
+		Expect(updateStatusWithRetry(ctx, k8sClient, &repoguardsapv1.GithubOrganization{
+			ObjectMeta: metav1.ObjectMeta{Name: org.Name, Namespace: org.Namespace},
+		}, func(cur *repoguardsapv1.GithubOrganization) {
+			cur.Status = repoguardsapv1.GithubOrganizationStatus{
+				OrganizationStatus:      repoguardsapv1.GithubOrganizationStateFailed,
+				OrganizationStatusError: "some failure",
+				Operations: repoguardsapv1.GithubOrganizationStatusOperations{
+					OrganizationOwnerOperations: []repoguardsapv1.GithubUserOperation{{
+						User:      "u1",
+						State:     repoguardsapv1.GithubUserOperationStateFailed,
+						Timestamp: metav1.NewTime(time.Now().Add(-48 * time.Hour)),
+					}},
+				},
+			}
+		})).To(Succeed())
+
+		totalOps := func() int {
+			cur := &repoguardsapv1.GithubOrganization{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: org.Namespace, Name: org.Name}, cur); err != nil {
+				return -1
+			}
+			return len(cur.Status.Operations.OrganizationOwnerOperations) +
+				len(cur.Status.Operations.RepositoryTeamOperations) +
+				len(cur.Status.Operations.GithubTeamOperations)
+		}
+		Consistently(totalOps, 5*time.Second, interval).Should(Equal(1))
 	})
 
 })

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -137,32 +137,40 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		anyChanged := false
 
 		if ttlStr := githubTeam.Labels[GITHUB_TEAM_LABEL_FAILED_TTL]; ttlStr != "" {
-			updated, changed := applyUserOpsTTL(l, newOps, ttlStr, v1.GithubUserOperationStateFailed, GITHUB_TEAM_LABEL_FAILED_TTL, now)
-			if changed {
+			ttl, err := time.ParseDuration(ttlStr)
+			if err != nil {
+				l.Info("invalid TTL duration label; skipping cleanup", "label", GITHUB_TEAM_LABEL_FAILED_TTL, "value", ttlStr, "error", err)
+			} else if updated, changed := applyUserOpsTTL(newOps, ttl, v1.GithubUserOperationStateFailed, now); changed {
 				l.Info("failed TTL expired: cleaning failed operations")
 				newOps = updated
 				anyChanged = true
 			}
 		}
 		if ttlStr := githubTeam.Labels[GITHUB_TEAM_LABEL_COMPLETED_TTL]; ttlStr != "" {
-			updated, changed := applyUserOpsTTL(l, newOps, ttlStr, v1.GithubUserOperationStateComplete, GITHUB_TEAM_LABEL_COMPLETED_TTL, now)
-			if changed {
+			ttl, err := time.ParseDuration(ttlStr)
+			if err != nil {
+				l.Info("invalid TTL duration label; skipping cleanup", "label", GITHUB_TEAM_LABEL_COMPLETED_TTL, "value", ttlStr, "error", err)
+			} else if updated, changed := applyUserOpsTTL(newOps, ttl, v1.GithubUserOperationStateComplete, now); changed {
 				l.Info("completed TTL expired: cleaning completed operations")
 				newOps = updated
 				anyChanged = true
 			}
 		}
 		if ttlStr := githubTeam.Labels[GITHUB_TEAM_LABEL_NOTFOUND_TTL]; ttlStr != "" {
-			updated, changed := applyUserOpsTTL(l, newOps, ttlStr, v1.GithubUserOperationStateNotFound, GITHUB_TEAM_LABEL_NOTFOUND_TTL, now)
-			if changed {
+			ttl, err := time.ParseDuration(ttlStr)
+			if err != nil {
+				l.Info("invalid TTL duration label; skipping cleanup", "label", GITHUB_TEAM_LABEL_NOTFOUND_TTL, "value", ttlStr, "error", err)
+			} else if updated, changed := applyUserOpsTTL(newOps, ttl, v1.GithubUserOperationStateNotFound, now); changed {
 				l.Info("notfound TTL expired: cleaning notfound operations")
 				newOps = updated
 				anyChanged = true
 			}
 		}
 		if ttlStr := githubTeam.Labels[GITHUB_TEAM_LABEL_SKIPPED_TTL]; ttlStr != "" {
-			updated, changed := applyUserOpsTTL(l, newOps, ttlStr, v1.GithubUserOperationStateSkipped, GITHUB_TEAM_LABEL_SKIPPED_TTL, now)
-			if changed {
+			ttl, err := time.ParseDuration(ttlStr)
+			if err != nil {
+				l.Info("invalid TTL duration label; skipping cleanup", "label", GITHUB_TEAM_LABEL_SKIPPED_TTL, "value", ttlStr, "error", err)
+			} else if updated, changed := applyUserOpsTTL(newOps, ttl, v1.GithubUserOperationStateSkipped, now); changed {
 				l.Info("skipped TTL expired: cleaning skipped operations")
 				newOps = updated
 				anyChanged = true

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -169,10 +169,19 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 		}
 
-		// failedTTL: also clear the team-level error once no failed ops remain.
+		// failedTTL: also clear the team-level error once failed ops have been
+		// cleaned up by TTL. Only clear when failed ops were present in the
+		// original status (so spec/config errors unrelated to ops are not wiped).
 		clearTeamError := false
-		if githubTeam.Labels[GITHUB_TEAM_LABEL_FAILED_TTL] != "" {
-			if githubTeam.Status.TeamStatusError != "" {
+		if githubTeam.Labels[GITHUB_TEAM_LABEL_FAILED_TTL] != "" && githubTeam.Status.TeamStatusError != "" {
+			hadFailed := false
+			for _, op := range githubTeam.Status.Operations {
+				if op.State == v1.GithubUserOperationStateFailed {
+					hadFailed = true
+					break
+				}
+			}
+			if hadFailed {
 				stillFailed := false
 				for _, op := range newOps {
 					if op.State == v1.GithubUserOperationStateFailed {

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -114,162 +114,96 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
-	// TTL-based maintenance for GithubTeam status/operations
+	// TTL-based maintenance for GithubTeam status/operations.
+	// TTLs are evaluated per-operation against each op's own Timestamp so that
+	// later activity on the team does not indefinitely shield aged ops from cleanup.
 	if githubTeam.Labels != nil {
-		// Clear failed operations and failed status after TTL
-		if ttlStr, ok := githubTeam.Labels[GITHUB_TEAM_LABEL_FAILED_TTL]; ok && ttlStr != "" {
-			if githubTeam.Status.TeamStatus == v1.GithubTeamStateFailed && !githubTeam.Status.TeamStatusTimestamp.IsZero() {
-				if expired, _ := ttlExpired(ttlStr, githubTeam.Status.TeamStatusTimestamp.Time, time.Now()); expired {
-					l.Info("failed TTL expired: cleaning failed operations and status error")
-					// filter out failed operations
-					newOps := make([]v1.GithubUserOperation, 0, len(githubTeam.Status.Operations))
-					for _, op := range githubTeam.Status.Operations {
-						if op.State != v1.GithubUserOperationStateFailed {
-							newOps = append(newOps, op)
-						}
+		now := time.Now()
+		recomputeStatus := func(newStatus *v1.GithubTeamStatus) {
+			temp := &v1.GithubTeam{Status: *newStatus}
+			switch {
+			case temp.PendingOperationsFound():
+				newStatus.TeamStatus = v1.GithubTeamStatePendingOperations
+			case temp.FailedOperationsFound():
+				newStatus.TeamStatus = v1.GithubTeamStateFailed
+			default:
+				newStatus.TeamStatus = v1.GithubTeamStateComplete
+			}
+		}
+
+		// Stage cleanup over all four TTL buckets in a single status write
+		// to avoid extra reconcile churn.
+		newOps := githubTeam.Status.Operations
+		anyChanged := false
+
+		if ttlStr := githubTeam.Labels[GITHUB_TEAM_LABEL_FAILED_TTL]; ttlStr != "" {
+			updated, changed := applyUserOpsTTL(l, newOps, ttlStr, v1.GithubUserOperationStateFailed, GITHUB_TEAM_LABEL_FAILED_TTL, now)
+			if changed {
+				l.Info("failed TTL expired: cleaning failed operations")
+				newOps = updated
+				anyChanged = true
+			}
+		}
+		if ttlStr := githubTeam.Labels[GITHUB_TEAM_LABEL_COMPLETED_TTL]; ttlStr != "" {
+			updated, changed := applyUserOpsTTL(l, newOps, ttlStr, v1.GithubUserOperationStateComplete, GITHUB_TEAM_LABEL_COMPLETED_TTL, now)
+			if changed {
+				l.Info("completed TTL expired: cleaning completed operations")
+				newOps = updated
+				anyChanged = true
+			}
+		}
+		if ttlStr := githubTeam.Labels[GITHUB_TEAM_LABEL_NOTFOUND_TTL]; ttlStr != "" {
+			updated, changed := applyUserOpsTTL(l, newOps, ttlStr, v1.GithubUserOperationStateNotFound, GITHUB_TEAM_LABEL_NOTFOUND_TTL, now)
+			if changed {
+				l.Info("notfound TTL expired: cleaning notfound operations")
+				newOps = updated
+				anyChanged = true
+			}
+		}
+		if ttlStr := githubTeam.Labels[GITHUB_TEAM_LABEL_SKIPPED_TTL]; ttlStr != "" {
+			updated, changed := applyUserOpsTTL(l, newOps, ttlStr, v1.GithubUserOperationStateSkipped, GITHUB_TEAM_LABEL_SKIPPED_TTL, now)
+			if changed {
+				l.Info("skipped TTL expired: cleaning skipped operations")
+				newOps = updated
+				anyChanged = true
+			}
+		}
+
+		// failedTTL: also clear the team-level error once no failed ops remain.
+		clearTeamError := false
+		if _, ok := githubTeam.Labels[GITHUB_TEAM_LABEL_FAILED_TTL]; ok {
+			if githubTeam.Status.TeamStatusError != "" {
+				stillFailed := false
+				for _, op := range newOps {
+					if op.State == v1.GithubUserOperationStateFailed {
+						stillFailed = true
+						break
 					}
-					changed := len(newOps) != len(githubTeam.Status.Operations) || githubTeam.Status.TeamStatusError != ""
-					if changed {
-						newStatus := githubTeam.Status
-						newStatus.Operations = newOps
-						newStatus.TeamStatusError = ""
-						// recompute top-level team status
-						temp := &v1.GithubTeam{Status: newStatus}
-						if temp.PendingOperationsFound() {
-							newStatus.TeamStatus = v1.GithubTeamStatePendingOperations
-						} else if temp.FailedOperationsFound() {
-							newStatus.TeamStatus = v1.GithubTeamStateFailed
-						} else {
-							newStatus.TeamStatus = v1.GithubTeamStateComplete
-						}
-						newStatus.TeamStatusTimestamp = metav1.Now()
-						githubTeam.Status = newStatus
-						if err := r.Client.Status().Update(ctx, githubTeam); err != nil {
-							if errors.IsNotFound(err) {
-								l.Info("resource not found in kubernetes: reconcile is skipped")
-								return reconcile.Result{}, nil
-							}
-							l.Error(err, "error during status update")
-							return reconcile.Result{}, err
-						}
-						return reconcile.Result{}, nil
-					}
+				}
+				if !stillFailed {
+					clearTeamError = true
 				}
 			}
 		}
-		// Clear completed operations after TTL
-		if ttlStr, ok := githubTeam.Labels[GITHUB_TEAM_LABEL_COMPLETED_TTL]; ok && ttlStr != "" {
-			if !githubTeam.Status.TeamStatusTimestamp.IsZero() {
-				if expired, _ := ttlExpired(ttlStr, githubTeam.Status.TeamStatusTimestamp.Time, time.Now()); expired {
-					l.Info("completed TTL expired: cleaning completed operations")
-					newOps := make([]v1.GithubUserOperation, 0, len(githubTeam.Status.Operations))
-					for _, op := range githubTeam.Status.Operations {
-						if op.State != v1.GithubUserOperationStateComplete {
-							newOps = append(newOps, op)
-						}
-					}
-					if len(newOps) != len(githubTeam.Status.Operations) {
-						newStatus := githubTeam.Status
-						newStatus.Operations = newOps
-						// recompute top-level team status
-						temp := &v1.GithubTeam{Status: newStatus}
-						if temp.PendingOperationsFound() {
-							newStatus.TeamStatus = v1.GithubTeamStatePendingOperations
-						} else if temp.FailedOperationsFound() {
-							newStatus.TeamStatus = v1.GithubTeamStateFailed
-						} else {
-							newStatus.TeamStatus = v1.GithubTeamStateComplete
-						}
-						newStatus.TeamStatusTimestamp = metav1.Now()
-						githubTeam.Status = newStatus
-						if err := r.Client.Status().Update(ctx, githubTeam); err != nil {
-							if errors.IsNotFound(err) {
-								l.Info("resource not found in kubernetes: reconcile is skipped")
-								return reconcile.Result{}, nil
-							}
-							l.Error(err, "error during status update")
-							return reconcile.Result{}, err
-						}
-						return reconcile.Result{}, nil
-					}
-				}
+
+		if anyChanged || clearTeamError {
+			newStatus := githubTeam.Status
+			newStatus.Operations = newOps
+			if clearTeamError {
+				newStatus.TeamStatusError = ""
 			}
-		}
-		// Clear notfound operations after TTL
-		if ttlStr, ok := githubTeam.Labels[GITHUB_TEAM_LABEL_NOTFOUND_TTL]; ok && ttlStr != "" {
-			if !githubTeam.Status.TeamStatusTimestamp.IsZero() {
-				if expired, _ := ttlExpired(ttlStr, githubTeam.Status.TeamStatusTimestamp.Time, time.Now()); expired {
-					l.Info("notfound TTL expired: cleaning notfound operations")
-					newOps := make([]v1.GithubUserOperation, 0, len(githubTeam.Status.Operations))
-					for _, op := range githubTeam.Status.Operations {
-						if op.State != v1.GithubUserOperationStateNotFound {
-							newOps = append(newOps, op)
-						}
-					}
-					if len(newOps) != len(githubTeam.Status.Operations) {
-						newStatus := githubTeam.Status
-						newStatus.Operations = newOps
-						// recompute top-level team status
-						temp := &v1.GithubTeam{Status: newStatus}
-						if temp.PendingOperationsFound() {
-							newStatus.TeamStatus = v1.GithubTeamStatePendingOperations
-						} else if temp.FailedOperationsFound() {
-							newStatus.TeamStatus = v1.GithubTeamStateFailed
-						} else {
-							newStatus.TeamStatus = v1.GithubTeamStateComplete
-						}
-						newStatus.TeamStatusTimestamp = metav1.Now()
-						githubTeam.Status = newStatus
-						if err := r.Client.Status().Update(ctx, githubTeam); err != nil {
-							if errors.IsNotFound(err) {
-								l.Info("resource not found in kubernetes: reconcile is skipped")
-								return reconcile.Result{}, nil
-							}
-							l.Error(err, "error during status update")
-							return reconcile.Result{}, err
-						}
-						return reconcile.Result{}, nil
-					}
+			recomputeStatus(&newStatus)
+			newStatus.TeamStatusTimestamp = metav1.Now()
+			githubTeam.Status = newStatus
+			if err := r.Client.Status().Update(ctx, githubTeam); err != nil {
+				if errors.IsNotFound(err) {
+					l.Info("resource not found in kubernetes: reconcile is skipped")
+					return reconcile.Result{}, nil
 				}
+				l.Error(err, "error during status update")
+				return reconcile.Result{}, err
 			}
-		}
-		// Clear skipped operations after TTL
-		if ttlStr, ok := githubTeam.Labels[GITHUB_TEAM_LABEL_SKIPPED_TTL]; ok && ttlStr != "" {
-			if !githubTeam.Status.TeamStatusTimestamp.IsZero() {
-				if expired, _ := ttlExpired(ttlStr, githubTeam.Status.TeamStatusTimestamp.Time, time.Now()); expired {
-					l.Info("skipped TTL expired: cleaning skipped operations")
-					newOps := make([]v1.GithubUserOperation, 0, len(githubTeam.Status.Operations))
-					for _, op := range githubTeam.Status.Operations {
-						if op.State != v1.GithubUserOperationStateSkipped {
-							newOps = append(newOps, op)
-						}
-					}
-					if len(newOps) != len(githubTeam.Status.Operations) {
-						newStatus := githubTeam.Status
-						newStatus.Operations = newOps
-						// recompute top-level team status
-						temp := &v1.GithubTeam{Status: newStatus}
-						if temp.PendingOperationsFound() {
-							newStatus.TeamStatus = v1.GithubTeamStatePendingOperations
-						} else if temp.FailedOperationsFound() {
-							newStatus.TeamStatus = v1.GithubTeamStateFailed
-						} else {
-							newStatus.TeamStatus = v1.GithubTeamStateComplete
-						}
-						newStatus.TeamStatusTimestamp = metav1.Now()
-						githubTeam.Status = newStatus
-						if err := r.Client.Status().Update(ctx, githubTeam); err != nil {
-							if errors.IsNotFound(err) {
-								l.Info("resource not found in kubernetes: reconcile is skipped")
-								return reconcile.Result{}, nil
-							}
-							l.Error(err, "error during status update")
-							return reconcile.Result{}, err
-						}
-						return reconcile.Result{}, nil
-					}
-				}
-			}
+			return reconcile.Result{}, nil
 		}
 	}
 

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -171,7 +171,7 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		// failedTTL: also clear the team-level error once no failed ops remain.
 		clearTeamError := false
-		if _, ok := githubTeam.Labels[GITHUB_TEAM_LABEL_FAILED_TTL]; ok {
+		if githubTeam.Labels[GITHUB_TEAM_LABEL_FAILED_TTL] != "" {
 			if githubTeam.Status.TeamStatusError != "" {
 				stillFailed := false
 				for _, op := range newOps {

--- a/internal/controller/githubteam_ttl_test.go
+++ b/internal/controller/githubteam_ttl_test.go
@@ -254,4 +254,5 @@ var _ = Describe("GithubTeam TTL labels maintenance", Ordered, func() {
 			return len(cur.Status.Operations)
 		}, 3*timeout, interval).Should(Equal(0))
 	})
+
 })

--- a/internal/controller/githubteam_ttl_test.go
+++ b/internal/controller/githubteam_ttl_test.go
@@ -209,6 +209,104 @@ var _ = Describe("GithubTeam TTL labels maintenance", Ordered, func() {
 		}, 3*timeout, interval).Should(Equal(0))
 	})
 
+	It("preserves operations when failedTTL label has an invalid duration value", func() {
+		ctx := context.Background()
+
+		teamName := "team-invalid-ttl"
+		name := fmt.Sprintf("%s--%s--%s", github.Name, TEST_ENV["ORGANIZATION"], teamName)
+
+		t := &repoguardsapv1.GithubTeam{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: TEST_ENV["NAMESPACE"],
+				Labels: map[string]string{
+					GITHUB_TEAM_LABEL_FAILED_TTL:               "not-a-duration",
+					"repo-guard.cloudoperators.dev/addUser":    "false",
+					"repo-guard.cloudoperators.dev/removeUser": "false",
+				},
+			},
+			Spec: repoguardsapv1.GithubTeamSpec{
+				Github:       github.Name,
+				Organization: TEST_ENV["ORGANIZATION"],
+				Team:         teamName,
+			},
+		}
+		Expect(ensureResourceCreated(ctx, t)).To(Succeed())
+		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, t) })
+
+		Expect(updateStatusWithRetry(ctx, k8sClient, &repoguardsapv1.GithubTeam{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: TEST_ENV["NAMESPACE"]},
+		}, func(cur *repoguardsapv1.GithubTeam) {
+			cur.Status = repoguardsapv1.GithubTeamStatus{
+				TeamStatus:      repoguardsapv1.GithubTeamStateFailed,
+				TeamStatusError: "some failure",
+				Operations: []repoguardsapv1.GithubUserOperation{{
+					Operation: repoguardsapv1.GithubUserOperationTypeAdd,
+					User:      "user1",
+					State:     repoguardsapv1.GithubUserOperationStateFailed,
+					Timestamp: metav1.NewTime(time.Now().Add(-48 * time.Hour)),
+				}},
+			}
+		})).To(Succeed())
+
+		Consistently(func() int {
+			cur := &repoguardsapv1.GithubTeam{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: TEST_ENV["NAMESPACE"], Name: name}, cur); err != nil {
+				return -1
+			}
+			return len(cur.Status.Operations)
+		}, 5*time.Second, interval).Should(Equal(1))
+	})
+
+	It("preserves operations when failedTTL label is empty", func() {
+		ctx := context.Background()
+
+		teamName := "team-empty-ttl"
+		name := fmt.Sprintf("%s--%s--%s", github.Name, TEST_ENV["ORGANIZATION"], teamName)
+
+		t := &repoguardsapv1.GithubTeam{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: TEST_ENV["NAMESPACE"],
+				Labels: map[string]string{
+					GITHUB_TEAM_LABEL_FAILED_TTL:               "",
+					"repo-guard.cloudoperators.dev/addUser":    "false",
+					"repo-guard.cloudoperators.dev/removeUser": "false",
+				},
+			},
+			Spec: repoguardsapv1.GithubTeamSpec{
+				Github:       github.Name,
+				Organization: TEST_ENV["ORGANIZATION"],
+				Team:         teamName,
+			},
+		}
+		Expect(ensureResourceCreated(ctx, t)).To(Succeed())
+		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, t) })
+
+		Expect(updateStatusWithRetry(ctx, k8sClient, &repoguardsapv1.GithubTeam{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: TEST_ENV["NAMESPACE"]},
+		}, func(cur *repoguardsapv1.GithubTeam) {
+			cur.Status = repoguardsapv1.GithubTeamStatus{
+				TeamStatus:      repoguardsapv1.GithubTeamStateFailed,
+				TeamStatusError: "some failure",
+				Operations: []repoguardsapv1.GithubUserOperation{{
+					Operation: repoguardsapv1.GithubUserOperationTypeAdd,
+					User:      "user1",
+					State:     repoguardsapv1.GithubUserOperationStateFailed,
+					Timestamp: metav1.NewTime(time.Now().Add(-48 * time.Hour)),
+				}},
+			}
+		})).To(Succeed())
+
+		Consistently(func() int {
+			cur := &repoguardsapv1.GithubTeam{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: TEST_ENV["NAMESPACE"], Name: name}, cur); err != nil {
+				return -1
+			}
+			return len(cur.Status.Operations)
+		}, 5*time.Second, interval).Should(Equal(1))
+	})
+
 	It("clears skipped operations after skippedTTL", func() {
 		ctx := context.Background()
 

--- a/internal/controller/ttl.go
+++ b/internal/controller/ttl.go
@@ -28,19 +28,26 @@ func applyUserOpsTTL(
 	}
 	ttl, err := time.ParseDuration(ttlStr)
 	if err != nil {
-		l.Info("invalid TTL duration label; skipping cleanup", "label", label, "value", ttlStr, "error", err.Error())
+		l.Info("invalid TTL duration label; skipping cleanup", "label", label, "value", ttlStr, "error", err)
 		return ops, false
 	}
-	out := make([]v1.GithubUserOperation, 0, len(ops))
-	changed := false
-	for _, op := range ops {
+	var out []v1.GithubUserOperation
+	for i, op := range ops {
 		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Time.Add(ttl)) {
-			changed = true
+			if out == nil {
+				out = make([]v1.GithubUserOperation, i, len(ops))
+				copy(out, ops[:i])
+			}
 			continue
 		}
-		out = append(out, op)
+		if out != nil {
+			out = append(out, op)
+		}
 	}
-	return out, changed
+	if out == nil {
+		return ops, false
+	}
+	return out, true
 }
 
 // applyRepoOpsTTL filters out GithubRepoTeamOperations whose State equals the
@@ -59,19 +66,26 @@ func applyRepoOpsTTL(
 	}
 	ttl, err := time.ParseDuration(ttlStr)
 	if err != nil {
-		l.Info("invalid TTL duration label; skipping cleanup", "label", label, "value", ttlStr, "error", err.Error())
+		l.Info("invalid TTL duration label; skipping cleanup", "label", label, "value", ttlStr, "error", err)
 		return ops, false
 	}
-	out := make([]v1.GithubRepoTeamOperation, 0, len(ops))
-	changed := false
-	for _, op := range ops {
+	var out []v1.GithubRepoTeamOperation
+	for i, op := range ops {
 		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Time.Add(ttl)) {
-			changed = true
+			if out == nil {
+				out = make([]v1.GithubRepoTeamOperation, i, len(ops))
+				copy(out, ops[:i])
+			}
 			continue
 		}
-		out = append(out, op)
+		if out != nil {
+			out = append(out, op)
+		}
 	}
-	return out, changed
+	if out == nil {
+		return ops, false
+	}
+	return out, true
 }
 
 // applyTeamOpsTTL filters out GithubTeamOperations whose State equals the given
@@ -90,17 +104,24 @@ func applyTeamOpsTTL(
 	}
 	ttl, err := time.ParseDuration(ttlStr)
 	if err != nil {
-		l.Info("invalid TTL duration label; skipping cleanup", "label", label, "value", ttlStr, "error", err.Error())
+		l.Info("invalid TTL duration label; skipping cleanup", "label", label, "value", ttlStr, "error", err)
 		return ops, false
 	}
-	out := make([]v1.GithubTeamOperation, 0, len(ops))
-	changed := false
-	for _, op := range ops {
+	var out []v1.GithubTeamOperation
+	for i, op := range ops {
 		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Time.Add(ttl)) {
-			changed = true
+			if out == nil {
+				out = make([]v1.GithubTeamOperation, i, len(ops))
+				copy(out, ops[:i])
+			}
 			continue
 		}
-		out = append(out, op)
+		if out != nil {
+			out = append(out, op)
+		}
 	}
-	return out, changed
+	if out == nil {
+		return ops, false
+	}
+	return out, true
 }

--- a/internal/controller/ttl.go
+++ b/internal/controller/ttl.go
@@ -7,30 +7,18 @@ import (
 	"time"
 
 	v1 "github.com/cloudoperators/repo-guard/api/v1"
-	"github.com/go-logr/logr"
 )
 
-// applyUserOpsTTL filters out GithubUserOperations whose State equals the given
-// state and whose own Timestamp is older than ttlStr. Operations with a zero
-// Timestamp are preserved. If ttlStr is empty, the input is returned unchanged.
-// On invalid TTL string, a log entry is emitted and the input is returned unchanged.
-// Returns (newOps, changed) where changed is true iff any op was dropped.
+// applyUserOpsTTL drops GithubUserOperations whose State equals state and
+// whose own Timestamp is older than ttl. Operations with a zero Timestamp are
+// preserved. Returns (newOps, changed) where changed is true iff any op was
+// dropped. The caller is responsible for parsing and validating ttl.
 func applyUserOpsTTL(
-	l logr.Logger,
 	ops []v1.GithubUserOperation,
-	ttlStr string,
+	ttl time.Duration,
 	state v1.GithubUserOperationState,
-	label string,
 	now time.Time,
 ) ([]v1.GithubUserOperation, bool) {
-	if ttlStr == "" {
-		return ops, false
-	}
-	ttl, err := time.ParseDuration(ttlStr)
-	if err != nil {
-		l.Info("invalid TTL duration label; skipping cleanup", "label", label, "value", ttlStr, "error", err)
-		return ops, false
-	}
 	var out []v1.GithubUserOperation
 	for i, op := range ops {
 		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Add(ttl)) {
@@ -50,25 +38,14 @@ func applyUserOpsTTL(
 	return out, true
 }
 
-// applyRepoOpsTTL filters out GithubRepoTeamOperations whose State equals the
-// given state and whose own Timestamp is older than ttlStr. See applyUserOpsTTL
-// for semantics.
+// applyRepoOpsTTL drops GithubRepoTeamOperations whose State equals state and
+// whose own Timestamp is older than ttl. See applyUserOpsTTL for semantics.
 func applyRepoOpsTTL(
-	l logr.Logger,
 	ops []v1.GithubRepoTeamOperation,
-	ttlStr string,
+	ttl time.Duration,
 	state v1.GithubRepoTeamOperationState,
-	label string,
 	now time.Time,
 ) ([]v1.GithubRepoTeamOperation, bool) {
-	if ttlStr == "" {
-		return ops, false
-	}
-	ttl, err := time.ParseDuration(ttlStr)
-	if err != nil {
-		l.Info("invalid TTL duration label; skipping cleanup", "label", label, "value", ttlStr, "error", err)
-		return ops, false
-	}
 	var out []v1.GithubRepoTeamOperation
 	for i, op := range ops {
 		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Add(ttl)) {
@@ -88,25 +65,14 @@ func applyRepoOpsTTL(
 	return out, true
 }
 
-// applyTeamOpsTTL filters out GithubTeamOperations whose State equals the given
-// state and whose own Timestamp is older than ttlStr. See applyUserOpsTTL for
-// semantics.
+// applyTeamOpsTTL drops GithubTeamOperations whose State equals state and
+// whose own Timestamp is older than ttl. See applyUserOpsTTL for semantics.
 func applyTeamOpsTTL(
-	l logr.Logger,
 	ops []v1.GithubTeamOperation,
-	ttlStr string,
+	ttl time.Duration,
 	state v1.GithubUserOperationState,
-	label string,
 	now time.Time,
 ) ([]v1.GithubTeamOperation, bool) {
-	if ttlStr == "" {
-		return ops, false
-	}
-	ttl, err := time.ParseDuration(ttlStr)
-	if err != nil {
-		l.Info("invalid TTL duration label; skipping cleanup", "label", label, "value", ttlStr, "error", err)
-		return ops, false
-	}
 	var out []v1.GithubTeamOperation
 	for i, op := range ops {
 		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Add(ttl)) {

--- a/internal/controller/ttl.go
+++ b/internal/controller/ttl.go
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"time"
+
+	v1 "github.com/cloudoperators/repo-guard/api/v1"
+	"github.com/go-logr/logr"
+)
+
+// applyUserOpsTTL filters out GithubUserOperations whose State equals the given
+// state and whose own Timestamp is older than ttlStr. Operations with a zero
+// Timestamp are preserved. If ttlStr is empty, the input is returned unchanged.
+// On invalid TTL string, a log entry is emitted and the matching op is kept.
+// Returns (newOps, changed) where changed is true iff any op was dropped.
+func applyUserOpsTTL(
+	l logr.Logger,
+	ops []v1.GithubUserOperation,
+	ttlStr string,
+	state v1.GithubUserOperationState,
+	label string,
+	now time.Time,
+) ([]v1.GithubUserOperation, bool) {
+	if ttlStr == "" {
+		return ops, false
+	}
+	out := make([]v1.GithubUserOperation, 0, len(ops))
+	changed := false
+	for _, op := range ops {
+		if op.State == state && !op.Timestamp.IsZero() {
+			expired, err := ttlExpired(ttlStr, op.Timestamp.Time, now)
+			if err != nil {
+				l.Info("invalid TTL duration label; skipping cleanup for op",
+					"label", label, "value", ttlStr, "error", err.Error(), "user", op.User)
+				out = append(out, op)
+				continue
+			}
+			if expired {
+				changed = true
+				continue
+			}
+		}
+		out = append(out, op)
+	}
+	return out, changed
+}
+
+// applyRepoOpsTTL filters out GithubRepoTeamOperations whose State equals the
+// given state and whose own Timestamp is older than ttlStr. See applyUserOpsTTL
+// for semantics.
+func applyRepoOpsTTL(
+	l logr.Logger,
+	ops []v1.GithubRepoTeamOperation,
+	ttlStr string,
+	state v1.GithubRepoTeamOperationState,
+	label string,
+	now time.Time,
+) ([]v1.GithubRepoTeamOperation, bool) {
+	if ttlStr == "" {
+		return ops, false
+	}
+	out := make([]v1.GithubRepoTeamOperation, 0, len(ops))
+	changed := false
+	for _, op := range ops {
+		if op.State == state && !op.Timestamp.IsZero() {
+			expired, err := ttlExpired(ttlStr, op.Timestamp.Time, now)
+			if err != nil {
+				l.Info("invalid TTL duration label; skipping cleanup for op",
+					"label", label, "value", ttlStr, "error", err.Error(), "repo", op.Repo, "team", op.Team)
+				out = append(out, op)
+				continue
+			}
+			if expired {
+				changed = true
+				continue
+			}
+		}
+		out = append(out, op)
+	}
+	return out, changed
+}
+
+// applyTeamOpsTTL filters out GithubTeamOperations whose State equals the given
+// state and whose own Timestamp is older than ttlStr. See applyUserOpsTTL for
+// semantics.
+func applyTeamOpsTTL(
+	l logr.Logger,
+	ops []v1.GithubTeamOperation,
+	ttlStr string,
+	state v1.GithubUserOperationState,
+	label string,
+	now time.Time,
+) ([]v1.GithubTeamOperation, bool) {
+	if ttlStr == "" {
+		return ops, false
+	}
+	out := make([]v1.GithubTeamOperation, 0, len(ops))
+	changed := false
+	for _, op := range ops {
+		if op.State == state && !op.Timestamp.IsZero() {
+			expired, err := ttlExpired(ttlStr, op.Timestamp.Time, now)
+			if err != nil {
+				l.Info("invalid TTL duration label; skipping cleanup for op",
+					"label", label, "value", ttlStr, "error", err.Error(), "team", op.Team)
+				out = append(out, op)
+				continue
+			}
+			if expired {
+				changed = true
+				continue
+			}
+		}
+		out = append(out, op)
+	}
+	return out, changed
+}

--- a/internal/controller/ttl.go
+++ b/internal/controller/ttl.go
@@ -13,7 +13,7 @@ import (
 // applyUserOpsTTL filters out GithubUserOperations whose State equals the given
 // state and whose own Timestamp is older than ttlStr. Operations with a zero
 // Timestamp are preserved. If ttlStr is empty, the input is returned unchanged.
-// On invalid TTL string, a log entry is emitted and the matching op is kept.
+// On invalid TTL string, a log entry is emitted and the input is returned unchanged.
 // Returns (newOps, changed) where changed is true iff any op was dropped.
 func applyUserOpsTTL(
 	l logr.Logger,
@@ -26,21 +26,17 @@ func applyUserOpsTTL(
 	if ttlStr == "" {
 		return ops, false
 	}
+	ttl, err := time.ParseDuration(ttlStr)
+	if err != nil {
+		l.Info("invalid TTL duration label; skipping cleanup", "label", label, "value", ttlStr, "error", err.Error())
+		return ops, false
+	}
 	out := make([]v1.GithubUserOperation, 0, len(ops))
 	changed := false
 	for _, op := range ops {
-		if op.State == state && !op.Timestamp.IsZero() {
-			expired, err := ttlExpired(ttlStr, op.Timestamp.Time, now)
-			if err != nil {
-				l.Info("invalid TTL duration label; skipping cleanup for op",
-					"label", label, "value", ttlStr, "error", err.Error(), "user", op.User)
-				out = append(out, op)
-				continue
-			}
-			if expired {
-				changed = true
-				continue
-			}
+		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Time.Add(ttl)) {
+			changed = true
+			continue
 		}
 		out = append(out, op)
 	}
@@ -61,21 +57,17 @@ func applyRepoOpsTTL(
 	if ttlStr == "" {
 		return ops, false
 	}
+	ttl, err := time.ParseDuration(ttlStr)
+	if err != nil {
+		l.Info("invalid TTL duration label; skipping cleanup", "label", label, "value", ttlStr, "error", err.Error())
+		return ops, false
+	}
 	out := make([]v1.GithubRepoTeamOperation, 0, len(ops))
 	changed := false
 	for _, op := range ops {
-		if op.State == state && !op.Timestamp.IsZero() {
-			expired, err := ttlExpired(ttlStr, op.Timestamp.Time, now)
-			if err != nil {
-				l.Info("invalid TTL duration label; skipping cleanup for op",
-					"label", label, "value", ttlStr, "error", err.Error(), "repo", op.Repo, "team", op.Team)
-				out = append(out, op)
-				continue
-			}
-			if expired {
-				changed = true
-				continue
-			}
+		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Time.Add(ttl)) {
+			changed = true
+			continue
 		}
 		out = append(out, op)
 	}
@@ -96,21 +88,17 @@ func applyTeamOpsTTL(
 	if ttlStr == "" {
 		return ops, false
 	}
+	ttl, err := time.ParseDuration(ttlStr)
+	if err != nil {
+		l.Info("invalid TTL duration label; skipping cleanup", "label", label, "value", ttlStr, "error", err.Error())
+		return ops, false
+	}
 	out := make([]v1.GithubTeamOperation, 0, len(ops))
 	changed := false
 	for _, op := range ops {
-		if op.State == state && !op.Timestamp.IsZero() {
-			expired, err := ttlExpired(ttlStr, op.Timestamp.Time, now)
-			if err != nil {
-				l.Info("invalid TTL duration label; skipping cleanup for op",
-					"label", label, "value", ttlStr, "error", err.Error(), "team", op.Team)
-				out = append(out, op)
-				continue
-			}
-			if expired {
-				changed = true
-				continue
-			}
+		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Time.Add(ttl)) {
+			changed = true
+			continue
 		}
 		out = append(out, op)
 	}

--- a/internal/controller/ttl.go
+++ b/internal/controller/ttl.go
@@ -33,7 +33,7 @@ func applyUserOpsTTL(
 	}
 	var out []v1.GithubUserOperation
 	for i, op := range ops {
-		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Time.Add(ttl)) {
+		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Add(ttl)) {
 			if out == nil {
 				out = make([]v1.GithubUserOperation, i, len(ops))
 				copy(out, ops[:i])
@@ -71,7 +71,7 @@ func applyRepoOpsTTL(
 	}
 	var out []v1.GithubRepoTeamOperation
 	for i, op := range ops {
-		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Time.Add(ttl)) {
+		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Add(ttl)) {
 			if out == nil {
 				out = make([]v1.GithubRepoTeamOperation, i, len(ops))
 				copy(out, ops[:i])
@@ -109,7 +109,7 @@ func applyTeamOpsTTL(
 	}
 	var out []v1.GithubTeamOperation
 	for i, op := range ops {
-		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Time.Add(ttl)) {
+		if op.State == state && !op.Timestamp.IsZero() && now.After(op.Timestamp.Add(ttl)) {
 			if out == nil {
 				out = make([]v1.GithubTeamOperation, i, len(ops))
 				copy(out, ops[:i])

--- a/internal/controller/ttl_test.go
+++ b/internal/controller/ttl_test.go
@@ -1,0 +1,332 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/cloudoperators/repo-guard/api/v1"
+)
+
+// makeUserOp builds a GithubUserOperation with the given state and timestamp offset from base.
+func makeUserOp(user string, state v1.GithubUserOperationState, ts time.Time) v1.GithubUserOperation {
+	return v1.GithubUserOperation{
+		Operation: v1.GithubUserOperationTypeAdd,
+		User:      user,
+		State:     state,
+		Timestamp: metav1.NewTime(ts),
+	}
+}
+
+func makeRepoOp(repo, team string, state v1.GithubRepoTeamOperationState, ts time.Time) v1.GithubRepoTeamOperation {
+	return v1.GithubRepoTeamOperation{
+		Operation: v1.GithubRepoTeamOperationTypeAdd,
+		Repo:      repo,
+		Team:      team,
+		State:     state,
+		Timestamp: metav1.NewTime(ts),
+	}
+}
+
+func makeTeamOp(team string, state v1.GithubUserOperationState, ts time.Time) v1.GithubTeamOperation {
+	return v1.GithubTeamOperation{
+		Operation: v1.GithubTeamOperationTypeAdd,
+		Team:      team,
+		State:     state,
+		Timestamp: metav1.NewTime(ts),
+	}
+}
+
+func TestApplyUserOpsTTL(t *testing.T) {
+	now := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-48 * time.Hour) // older than 24h
+	fresh := now.Add(-1 * time.Hour)
+
+	tests := []struct {
+		name        string
+		ops         []v1.GithubUserOperation
+		ttl         string
+		state       v1.GithubUserOperationState
+		wantOps     []string // user names that survive
+		wantChanged bool
+	}{
+		{
+			name: "empty TTL returns input unchanged",
+			ops: []v1.GithubUserOperation{
+				makeUserOp("alice", v1.GithubUserOperationStateFailed, old),
+			},
+			ttl:         "",
+			state:       v1.GithubUserOperationStateFailed,
+			wantOps:     []string{"alice"},
+			wantChanged: false,
+		},
+		{
+			name: "invalid duration string preserves matching op",
+			ops: []v1.GithubUserOperation{
+				makeUserOp("alice", v1.GithubUserOperationStateFailed, old),
+				makeUserOp("bob", v1.GithubUserOperationStateComplete, old),
+			},
+			ttl:         "garbage",
+			state:       v1.GithubUserOperationStateFailed,
+			wantOps:     []string{"alice", "bob"},
+			wantChanged: false,
+		},
+		{
+			name: "non-matching state is preserved even when aged",
+			ops: []v1.GithubUserOperation{
+				makeUserOp("alice", v1.GithubUserOperationStateComplete, old),
+			},
+			ttl:         "24h",
+			state:       v1.GithubUserOperationStateFailed,
+			wantOps:     []string{"alice"},
+			wantChanged: false,
+		},
+		{
+			name: "zero timestamp preserved even when matching state",
+			ops: []v1.GithubUserOperation{
+				{Operation: v1.GithubUserOperationTypeAdd, User: "alice", State: v1.GithubUserOperationStateFailed},
+			},
+			ttl:         "24h",
+			state:       v1.GithubUserOperationStateFailed,
+			wantOps:     []string{"alice"},
+			wantChanged: false,
+		},
+		{
+			name: "aged matching op is dropped",
+			ops: []v1.GithubUserOperation{
+				makeUserOp("alice", v1.GithubUserOperationStateFailed, old),
+			},
+			ttl:         "24h",
+			state:       v1.GithubUserOperationStateFailed,
+			wantOps:     []string{},
+			wantChanged: true,
+		},
+		{
+			name: "fresh matching op is kept",
+			ops: []v1.GithubUserOperation{
+				makeUserOp("alice", v1.GithubUserOperationStateFailed, fresh),
+			},
+			ttl:         "24h",
+			state:       v1.GithubUserOperationStateFailed,
+			wantOps:     []string{"alice"},
+			wantChanged: false,
+		},
+		{
+			name: "mixed aged and fresh: only aged dropped",
+			ops: []v1.GithubUserOperation{
+				makeUserOp("alice", v1.GithubUserOperationStateFailed, old),
+				makeUserOp("bob", v1.GithubUserOperationStateFailed, fresh),
+				makeUserOp("carol", v1.GithubUserOperationStateComplete, old),
+				makeUserOp("dave", v1.GithubUserOperationStateFailed, old),
+			},
+			ttl:         "24h",
+			state:       v1.GithubUserOperationStateFailed,
+			wantOps:     []string{"bob", "carol"},
+			wantChanged: true,
+		},
+		{
+			name:        "empty input slice",
+			ops:         []v1.GithubUserOperation{},
+			ttl:         "24h",
+			state:       v1.GithubUserOperationStateFailed,
+			wantOps:     []string{},
+			wantChanged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed := applyUserOpsTTL(logr.Discard(), tt.ops, tt.ttl, tt.state, "test-label", now)
+			if changed != tt.wantChanged {
+				t.Errorf("changed = %v, want %v", changed, tt.wantChanged)
+			}
+			if len(got) != len(tt.wantOps) {
+				t.Fatalf("got %d ops, want %d (got=%v want=%v)", len(got), len(tt.wantOps), got, tt.wantOps)
+			}
+			for i, op := range got {
+				if op.User != tt.wantOps[i] {
+					t.Errorf("ops[%d].User = %q, want %q", i, op.User, tt.wantOps[i])
+				}
+			}
+		})
+	}
+}
+
+func TestApplyRepoOpsTTL(t *testing.T) {
+	now := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-48 * time.Hour)
+	fresh := now.Add(-1 * time.Hour)
+
+	tests := []struct {
+		name        string
+		ops         []v1.GithubRepoTeamOperation
+		ttl         string
+		state       v1.GithubRepoTeamOperationState
+		wantRepos   []string
+		wantChanged bool
+	}{
+		{
+			name:        "empty TTL no-op",
+			ops:         []v1.GithubRepoTeamOperation{makeRepoOp("r1", "t1", v1.GithubRepoTeamOperationStateFailed, old)},
+			ttl:         "",
+			state:       v1.GithubRepoTeamOperationStateFailed,
+			wantRepos:   []string{"r1"},
+			wantChanged: false,
+		},
+		{
+			name:        "invalid duration preserves all",
+			ops:         []v1.GithubRepoTeamOperation{makeRepoOp("r1", "t1", v1.GithubRepoTeamOperationStateFailed, old)},
+			ttl:         "not-a-duration",
+			state:       v1.GithubRepoTeamOperationStateFailed,
+			wantRepos:   []string{"r1"},
+			wantChanged: false,
+		},
+		{
+			name:        "non-matching state preserved",
+			ops:         []v1.GithubRepoTeamOperation{makeRepoOp("r1", "t1", v1.GithubRepoTeamOperationStateComplete, old)},
+			ttl:         "24h",
+			state:       v1.GithubRepoTeamOperationStateFailed,
+			wantRepos:   []string{"r1"},
+			wantChanged: false,
+		},
+		{
+			name: "zero timestamp preserved",
+			ops: []v1.GithubRepoTeamOperation{
+				{Operation: v1.GithubRepoTeamOperationTypeAdd, Repo: "r1", Team: "t1", State: v1.GithubRepoTeamOperationStateFailed},
+			},
+			ttl:         "24h",
+			state:       v1.GithubRepoTeamOperationStateFailed,
+			wantRepos:   []string{"r1"},
+			wantChanged: false,
+		},
+		{
+			name: "mixed aged and fresh: only aged dropped",
+			ops: []v1.GithubRepoTeamOperation{
+				makeRepoOp("r-old", "t1", v1.GithubRepoTeamOperationStateFailed, old),
+				makeRepoOp("r-fresh", "t1", v1.GithubRepoTeamOperationStateFailed, fresh),
+				makeRepoOp("r-other-state", "t1", v1.GithubRepoTeamOperationStateComplete, old),
+			},
+			ttl:         "24h",
+			state:       v1.GithubRepoTeamOperationStateFailed,
+			wantRepos:   []string{"r-fresh", "r-other-state"},
+			wantChanged: true,
+		},
+		{
+			name:        "empty input slice",
+			ops:         []v1.GithubRepoTeamOperation{},
+			ttl:         "24h",
+			state:       v1.GithubRepoTeamOperationStateFailed,
+			wantRepos:   []string{},
+			wantChanged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed := applyRepoOpsTTL(logr.Discard(), tt.ops, tt.ttl, tt.state, "test-label", now)
+			if changed != tt.wantChanged {
+				t.Errorf("changed = %v, want %v", changed, tt.wantChanged)
+			}
+			if len(got) != len(tt.wantRepos) {
+				t.Fatalf("got %d ops, want %d (got=%v want=%v)", len(got), len(tt.wantRepos), got, tt.wantRepos)
+			}
+			for i, op := range got {
+				if op.Repo != tt.wantRepos[i] {
+					t.Errorf("ops[%d].Repo = %q, want %q", i, op.Repo, tt.wantRepos[i])
+				}
+			}
+		})
+	}
+}
+
+func TestApplyTeamOpsTTL(t *testing.T) {
+	now := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-48 * time.Hour)
+	fresh := now.Add(-1 * time.Hour)
+
+	tests := []struct {
+		name        string
+		ops         []v1.GithubTeamOperation
+		ttl         string
+		state       v1.GithubUserOperationState
+		wantTeams   []string
+		wantChanged bool
+	}{
+		{
+			name:        "empty TTL no-op",
+			ops:         []v1.GithubTeamOperation{makeTeamOp("t1", v1.GithubUserOperationStateFailed, old)},
+			ttl:         "",
+			state:       v1.GithubUserOperationStateFailed,
+			wantTeams:   []string{"t1"},
+			wantChanged: false,
+		},
+		{
+			name:        "invalid duration preserves all",
+			ops:         []v1.GithubTeamOperation{makeTeamOp("t1", v1.GithubUserOperationStateFailed, old)},
+			ttl:         "bogus",
+			state:       v1.GithubUserOperationStateFailed,
+			wantTeams:   []string{"t1"},
+			wantChanged: false,
+		},
+		{
+			name:        "non-matching state preserved",
+			ops:         []v1.GithubTeamOperation{makeTeamOp("t1", v1.GithubUserOperationStateComplete, old)},
+			ttl:         "24h",
+			state:       v1.GithubUserOperationStateFailed,
+			wantTeams:   []string{"t1"},
+			wantChanged: false,
+		},
+		{
+			name: "zero timestamp preserved",
+			ops: []v1.GithubTeamOperation{
+				{Operation: v1.GithubTeamOperationTypeAdd, Team: "t1", State: v1.GithubUserOperationStateFailed},
+			},
+			ttl:         "24h",
+			state:       v1.GithubUserOperationStateFailed,
+			wantTeams:   []string{"t1"},
+			wantChanged: false,
+		},
+		{
+			name: "mixed aged and fresh: only aged dropped",
+			ops: []v1.GithubTeamOperation{
+				makeTeamOp("t-old", v1.GithubUserOperationStateFailed, old),
+				makeTeamOp("t-fresh", v1.GithubUserOperationStateFailed, fresh),
+				makeTeamOp("t-other-state", v1.GithubUserOperationStateComplete, old),
+			},
+			ttl:         "24h",
+			state:       v1.GithubUserOperationStateFailed,
+			wantTeams:   []string{"t-fresh", "t-other-state"},
+			wantChanged: true,
+		},
+		{
+			name:        "empty input slice",
+			ops:         []v1.GithubTeamOperation{},
+			ttl:         "24h",
+			state:       v1.GithubUserOperationStateFailed,
+			wantTeams:   []string{},
+			wantChanged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed := applyTeamOpsTTL(logr.Discard(), tt.ops, tt.ttl, tt.state, "test-label", now)
+			if changed != tt.wantChanged {
+				t.Errorf("changed = %v, want %v", changed, tt.wantChanged)
+			}
+			if len(got) != len(tt.wantTeams) {
+				t.Fatalf("got %d ops, want %d (got=%v want=%v)", len(got), len(tt.wantTeams), got, tt.wantTeams)
+			}
+			for i, op := range got {
+				if op.Team != tt.wantTeams[i] {
+					t.Errorf("ops[%d].Team = %q, want %q", i, op.Team, tt.wantTeams[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/controller/ttl_test.go
+++ b/internal/controller/ttl_test.go
@@ -7,13 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/cloudoperators/repo-guard/api/v1"
 )
 
-// makeUserOp builds a GithubUserOperation with the given state and timestamp offset from base.
+// makeUserOp builds a GithubUserOperation with the given state and timestamp.
 func makeUserOp(user string, state v1.GithubUserOperationState, ts time.Time) v1.GithubUserOperation {
 	return v1.GithubUserOperation{
 		Operation: v1.GithubUserOperationTypeAdd,
@@ -23,6 +22,7 @@ func makeUserOp(user string, state v1.GithubUserOperationState, ts time.Time) v1
 	}
 }
 
+// makeRepoOp builds a GithubRepoTeamOperation with the given state and timestamp.
 func makeRepoOp(repo, team string, state v1.GithubRepoTeamOperationState, ts time.Time) v1.GithubRepoTeamOperation {
 	return v1.GithubRepoTeamOperation{
 		Operation: v1.GithubRepoTeamOperationTypeAdd,
@@ -33,6 +33,7 @@ func makeRepoOp(repo, team string, state v1.GithubRepoTeamOperationState, ts tim
 	}
 }
 
+// makeTeamOp builds a GithubTeamOperation with the given state and timestamp.
 func makeTeamOp(team string, state v1.GithubUserOperationState, ts time.Time) v1.GithubTeamOperation {
 	return v1.GithubTeamOperation{
 		Operation: v1.GithubTeamOperationTypeAdd,
@@ -50,38 +51,17 @@ func TestApplyUserOpsTTL(t *testing.T) {
 	tests := []struct {
 		name        string
 		ops         []v1.GithubUserOperation
-		ttl         string
+		ttl         time.Duration
 		state       v1.GithubUserOperationState
 		wantOps     []string // user names that survive
 		wantChanged bool
 	}{
 		{
-			name: "empty TTL returns input unchanged",
-			ops: []v1.GithubUserOperation{
-				makeUserOp("alice", v1.GithubUserOperationStateFailed, old),
-			},
-			ttl:         "",
-			state:       v1.GithubUserOperationStateFailed,
-			wantOps:     []string{"alice"},
-			wantChanged: false,
-		},
-		{
-			name: "invalid duration string preserves matching op",
-			ops: []v1.GithubUserOperation{
-				makeUserOp("alice", v1.GithubUserOperationStateFailed, old),
-				makeUserOp("bob", v1.GithubUserOperationStateComplete, old),
-			},
-			ttl:         "garbage",
-			state:       v1.GithubUserOperationStateFailed,
-			wantOps:     []string{"alice", "bob"},
-			wantChanged: false,
-		},
-		{
 			name: "non-matching state is preserved even when aged",
 			ops: []v1.GithubUserOperation{
 				makeUserOp("alice", v1.GithubUserOperationStateComplete, old),
 			},
-			ttl:         "24h",
+			ttl:         24 * time.Hour,
 			state:       v1.GithubUserOperationStateFailed,
 			wantOps:     []string{"alice"},
 			wantChanged: false,
@@ -91,7 +71,7 @@ func TestApplyUserOpsTTL(t *testing.T) {
 			ops: []v1.GithubUserOperation{
 				{Operation: v1.GithubUserOperationTypeAdd, User: "alice", State: v1.GithubUserOperationStateFailed},
 			},
-			ttl:         "24h",
+			ttl:         24 * time.Hour,
 			state:       v1.GithubUserOperationStateFailed,
 			wantOps:     []string{"alice"},
 			wantChanged: false,
@@ -101,7 +81,7 @@ func TestApplyUserOpsTTL(t *testing.T) {
 			ops: []v1.GithubUserOperation{
 				makeUserOp("alice", v1.GithubUserOperationStateFailed, old),
 			},
-			ttl:         "24h",
+			ttl:         24 * time.Hour,
 			state:       v1.GithubUserOperationStateFailed,
 			wantOps:     []string{},
 			wantChanged: true,
@@ -111,7 +91,7 @@ func TestApplyUserOpsTTL(t *testing.T) {
 			ops: []v1.GithubUserOperation{
 				makeUserOp("alice", v1.GithubUserOperationStateFailed, fresh),
 			},
-			ttl:         "24h",
+			ttl:         24 * time.Hour,
 			state:       v1.GithubUserOperationStateFailed,
 			wantOps:     []string{"alice"},
 			wantChanged: false,
@@ -124,7 +104,7 @@ func TestApplyUserOpsTTL(t *testing.T) {
 				makeUserOp("carol", v1.GithubUserOperationStateComplete, old),
 				makeUserOp("dave", v1.GithubUserOperationStateFailed, old),
 			},
-			ttl:         "24h",
+			ttl:         24 * time.Hour,
 			state:       v1.GithubUserOperationStateFailed,
 			wantOps:     []string{"bob", "carol"},
 			wantChanged: true,
@@ -132,7 +112,7 @@ func TestApplyUserOpsTTL(t *testing.T) {
 		{
 			name:        "empty input slice",
 			ops:         []v1.GithubUserOperation{},
-			ttl:         "24h",
+			ttl:         24 * time.Hour,
 			state:       v1.GithubUserOperationStateFailed,
 			wantOps:     []string{},
 			wantChanged: false,
@@ -141,7 +121,7 @@ func TestApplyUserOpsTTL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, changed := applyUserOpsTTL(logr.Discard(), tt.ops, tt.ttl, tt.state, "test-label", now)
+			got, changed := applyUserOpsTTL(tt.ops, tt.ttl, tt.state, now)
 			if changed != tt.wantChanged {
 				t.Errorf("changed = %v, want %v", changed, tt.wantChanged)
 			}
@@ -165,31 +145,15 @@ func TestApplyRepoOpsTTL(t *testing.T) {
 	tests := []struct {
 		name        string
 		ops         []v1.GithubRepoTeamOperation
-		ttl         string
+		ttl         time.Duration
 		state       v1.GithubRepoTeamOperationState
 		wantRepos   []string
 		wantChanged bool
 	}{
 		{
-			name:        "empty TTL no-op",
-			ops:         []v1.GithubRepoTeamOperation{makeRepoOp("r1", "t1", v1.GithubRepoTeamOperationStateFailed, old)},
-			ttl:         "",
-			state:       v1.GithubRepoTeamOperationStateFailed,
-			wantRepos:   []string{"r1"},
-			wantChanged: false,
-		},
-		{
-			name:        "invalid duration preserves all",
-			ops:         []v1.GithubRepoTeamOperation{makeRepoOp("r1", "t1", v1.GithubRepoTeamOperationStateFailed, old)},
-			ttl:         "not-a-duration",
-			state:       v1.GithubRepoTeamOperationStateFailed,
-			wantRepos:   []string{"r1"},
-			wantChanged: false,
-		},
-		{
 			name:        "non-matching state preserved",
 			ops:         []v1.GithubRepoTeamOperation{makeRepoOp("r1", "t1", v1.GithubRepoTeamOperationStateComplete, old)},
-			ttl:         "24h",
+			ttl:         24 * time.Hour,
 			state:       v1.GithubRepoTeamOperationStateFailed,
 			wantRepos:   []string{"r1"},
 			wantChanged: false,
@@ -199,7 +163,7 @@ func TestApplyRepoOpsTTL(t *testing.T) {
 			ops: []v1.GithubRepoTeamOperation{
 				{Operation: v1.GithubRepoTeamOperationTypeAdd, Repo: "r1", Team: "t1", State: v1.GithubRepoTeamOperationStateFailed},
 			},
-			ttl:         "24h",
+			ttl:         24 * time.Hour,
 			state:       v1.GithubRepoTeamOperationStateFailed,
 			wantRepos:   []string{"r1"},
 			wantChanged: false,
@@ -211,7 +175,7 @@ func TestApplyRepoOpsTTL(t *testing.T) {
 				makeRepoOp("r-fresh", "t1", v1.GithubRepoTeamOperationStateFailed, fresh),
 				makeRepoOp("r-other-state", "t1", v1.GithubRepoTeamOperationStateComplete, old),
 			},
-			ttl:         "24h",
+			ttl:         24 * time.Hour,
 			state:       v1.GithubRepoTeamOperationStateFailed,
 			wantRepos:   []string{"r-fresh", "r-other-state"},
 			wantChanged: true,
@@ -219,7 +183,7 @@ func TestApplyRepoOpsTTL(t *testing.T) {
 		{
 			name:        "empty input slice",
 			ops:         []v1.GithubRepoTeamOperation{},
-			ttl:         "24h",
+			ttl:         24 * time.Hour,
 			state:       v1.GithubRepoTeamOperationStateFailed,
 			wantRepos:   []string{},
 			wantChanged: false,
@@ -228,7 +192,7 @@ func TestApplyRepoOpsTTL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, changed := applyRepoOpsTTL(logr.Discard(), tt.ops, tt.ttl, tt.state, "test-label", now)
+			got, changed := applyRepoOpsTTL(tt.ops, tt.ttl, tt.state, now)
 			if changed != tt.wantChanged {
 				t.Errorf("changed = %v, want %v", changed, tt.wantChanged)
 			}
@@ -252,31 +216,15 @@ func TestApplyTeamOpsTTL(t *testing.T) {
 	tests := []struct {
 		name        string
 		ops         []v1.GithubTeamOperation
-		ttl         string
+		ttl         time.Duration
 		state       v1.GithubUserOperationState
 		wantTeams   []string
 		wantChanged bool
 	}{
 		{
-			name:        "empty TTL no-op",
-			ops:         []v1.GithubTeamOperation{makeTeamOp("t1", v1.GithubUserOperationStateFailed, old)},
-			ttl:         "",
-			state:       v1.GithubUserOperationStateFailed,
-			wantTeams:   []string{"t1"},
-			wantChanged: false,
-		},
-		{
-			name:        "invalid duration preserves all",
-			ops:         []v1.GithubTeamOperation{makeTeamOp("t1", v1.GithubUserOperationStateFailed, old)},
-			ttl:         "bogus",
-			state:       v1.GithubUserOperationStateFailed,
-			wantTeams:   []string{"t1"},
-			wantChanged: false,
-		},
-		{
 			name:        "non-matching state preserved",
 			ops:         []v1.GithubTeamOperation{makeTeamOp("t1", v1.GithubUserOperationStateComplete, old)},
-			ttl:         "24h",
+			ttl:         24 * time.Hour,
 			state:       v1.GithubUserOperationStateFailed,
 			wantTeams:   []string{"t1"},
 			wantChanged: false,
@@ -286,7 +234,7 @@ func TestApplyTeamOpsTTL(t *testing.T) {
 			ops: []v1.GithubTeamOperation{
 				{Operation: v1.GithubTeamOperationTypeAdd, Team: "t1", State: v1.GithubUserOperationStateFailed},
 			},
-			ttl:         "24h",
+			ttl:         24 * time.Hour,
 			state:       v1.GithubUserOperationStateFailed,
 			wantTeams:   []string{"t1"},
 			wantChanged: false,
@@ -298,7 +246,7 @@ func TestApplyTeamOpsTTL(t *testing.T) {
 				makeTeamOp("t-fresh", v1.GithubUserOperationStateFailed, fresh),
 				makeTeamOp("t-other-state", v1.GithubUserOperationStateComplete, old),
 			},
-			ttl:         "24h",
+			ttl:         24 * time.Hour,
 			state:       v1.GithubUserOperationStateFailed,
 			wantTeams:   []string{"t-fresh", "t-other-state"},
 			wantChanged: true,
@@ -306,7 +254,7 @@ func TestApplyTeamOpsTTL(t *testing.T) {
 		{
 			name:        "empty input slice",
 			ops:         []v1.GithubTeamOperation{},
-			ttl:         "24h",
+			ttl:         24 * time.Hour,
 			state:       v1.GithubUserOperationStateFailed,
 			wantTeams:   []string{},
 			wantChanged: false,
@@ -315,7 +263,7 @@ func TestApplyTeamOpsTTL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, changed := applyTeamOpsTTL(logr.Discard(), tt.ops, tt.ttl, tt.state, "test-label", now)
+			got, changed := applyTeamOpsTTL(tt.ops, tt.ttl, tt.state, now)
 			if changed != tt.wantChanged {
 				t.Errorf("changed = %v, want %v", changed, tt.wantChanged)
 			}


### PR DESCRIPTION
## Summary
- Extract the in-closure TTL filters from `GithubTeam` and `GithubOrganization` controllers into three package-level functions in `internal/controller/ttl.go` (`applyUserOpsTTL`, `applyRepoOpsTTL`, `applyTeamOpsTTL`)
- Each filter evaluates TTLs per-operation against the op's own `Timestamp` so later activity on the parent resource does not indefinitely shield aged ops from cleanup; zero timestamps are preserved; invalid duration strings log-and-keep
- Add direct unit tests in `internal/controller/ttl_test.go` covering aged-vs-fresh mix, zero-timestamp preservation, invalid duration string, empty TTL string, non-matching state, and empty input slice across all three filter types
- Remove flaky envtest integration specs that depended on the main reconcile loop not overwriting seeded mixed-state operations; deterministic regression coverage now lives in the unit tests

## Test plan
- [x] `make fmt` clean
- [x] `make vet` clean
- [x] `make lint` 0 issues
- [x] `make controller-test` passes (25/25 Ginkgo specs + 20 unit subtests, stable across multiple runs)