### PR TITLE
chore: prepare release 4.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/cloudoperators/repo-guard:4.6.0
+IMG ?= ghcr.io/cloudoperators/repo-guard:4.7.0
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0
 

--- a/charts/repo-guard/Chart.yaml
+++ b/charts/repo-guard/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: repo-guard
 description: A Helm chart for Kubernetes
 type: application
-version: 4.6.0
-appVersion: "4.6.0"
+version: 4.7.0
+appVersion: "4.7.0"


### PR DESCRIPTION
Automated version bump to 4.7.0 for release.