### PR TITLE
fix(controller): recover from rate limit errors that have already reset

### DIFF
--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -344,10 +344,6 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 			// Check for GitHub rate limit and requeue accordingly
 			if t, ok := parseGitHubRateLimitReset(err.Error()); ok {
 				now := time.Now().UTC()
-				requeue := time.Duration(0)
-				if t.After(now) {
-					requeue = t.Sub(now)
-				}
 				githubOrganization.Status.OrganizationStatus = v1.GithubOrganizationStateRateLimited
 				githubOrganization.Status.OrganizationStatusError = "error in getting organization owners: " + err.Error()
 				githubOrganization.Status.OrganizationStatusTimestamp = metav1.Now()
@@ -364,7 +360,10 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 					l.Error(uerr, "error during status update")
 					return reconcile.Result{}, uerr
 				}
-				return reconcile.Result{RequeueAfter: requeue}, nil
+				if t.After(now) {
+					return reconcile.Result{RequeueAfter: t.Sub(now)}, nil
+				}
+				return reconcile.Result{Requeue: true}, nil
 			}
 			githubOrganization.Status.OrganizationStatus = v1.GithubOrganizationStateFailed
 			githubOrganization.Status.OrganizationStatusError = "error in getting organization owners: " + err.Error()
@@ -390,10 +389,6 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 			l.Error(err, "error in getting teams from github")
 			if t, ok := parseGitHubRateLimitReset(err.Error()); ok {
 				now := time.Now().UTC()
-				requeue := time.Duration(0)
-				if t.After(now) {
-					requeue = t.Sub(now)
-				}
 				githubOrganization.Status.OrganizationStatus = v1.GithubOrganizationStateRateLimited
 				githubOrganization.Status.OrganizationStatusError = "error in getting teams: " + err.Error()
 				githubOrganization.Status.OrganizationStatusTimestamp = metav1.Now()
@@ -410,7 +405,10 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 					l.Error(uerr, "error during status update")
 					return reconcile.Result{}, uerr
 				}
-				return reconcile.Result{RequeueAfter: requeue}, nil
+				if t.After(now) {
+					return reconcile.Result{RequeueAfter: t.Sub(now)}, nil
+				}
+				return reconcile.Result{Requeue: true}, nil
 			}
 			githubOrganization.Status.OrganizationStatus = v1.GithubOrganizationStateFailed
 			githubOrganization.Status.OrganizationStatusError = "error in getting teams: " + err.Error()
@@ -436,10 +434,6 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 			l.Error(err, "error in getting teams from github")
 			if t, ok := parseGitHubRateLimitReset(err.Error()); ok {
 				now := time.Now().UTC()
-				requeue := time.Duration(0)
-				if t.After(now) {
-					requeue = t.Sub(now)
-				}
 				githubOrganization.Status.OrganizationStatus = v1.GithubOrganizationStateRateLimited
 				githubOrganization.Status.OrganizationStatusError = "error in getting teams: " + err.Error()
 				githubOrganization.Status.OrganizationStatusTimestamp = metav1.Now()
@@ -456,7 +450,10 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 					l.Error(uerr, "error during status update")
 					return reconcile.Result{}, uerr
 				}
-				return reconcile.Result{RequeueAfter: requeue}, nil
+				if t.After(now) {
+					return reconcile.Result{RequeueAfter: t.Sub(now)}, nil
+				}
+				return reconcile.Result{Requeue: true}, nil
 			}
 			githubOrganization.Status.OrganizationStatus = v1.GithubOrganizationStateFailed
 			githubOrganization.Status.OrganizationStatusError = "error in getting teams: " + err.Error()

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -459,10 +459,6 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			l.Error(err, "error during listing organization teams")
 			if t, ok := parseGitHubRateLimitReset(err.Error()); ok {
 				now := time.Now().UTC()
-				requeue := time.Duration(0)
-				if t.After(now) {
-					requeue = t.Sub(now)
-				}
 				githubTeam.Status.TeamStatus = v1.GithubTeamStateRateLimited
 				githubTeam.Status.TeamStatusError = "error during listing organization teams: " + err.Error()
 				githubTeam.Status.TeamStatusTimestamp = metav1.Now()
@@ -470,7 +466,10 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					l.Error(uerr, "error during status update")
 					return reconcile.Result{}, uerr
 				}
-				return reconcile.Result{RequeueAfter: requeue}, nil
+				if t.After(now) {
+					return reconcile.Result{RequeueAfter: t.Sub(now)}, nil
+				}
+				return reconcile.Result{Requeue: true}, nil
 			}
 			return reconcile.Result{}, err
 		}
@@ -488,10 +487,6 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				l.Error(err, "error during adding team to Github")
 				if t, ok := parseGitHubRateLimitReset(err.Error()); ok {
 					now := time.Now().UTC()
-					requeue := time.Duration(0)
-					if t.After(now) {
-						requeue = t.Sub(now)
-					}
 					githubTeam.Status.TeamStatus = v1.GithubTeamStateRateLimited
 					githubTeam.Status.TeamStatusError = "error during adding team to Github: " + err.Error()
 					githubTeam.Status.TeamStatusTimestamp = metav1.Now()
@@ -499,7 +494,10 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 						l.Error(uerr, "error during status update")
 						return reconcile.Result{}, uerr
 					}
-					return reconcile.Result{RequeueAfter: requeue}, nil
+					if t.After(now) {
+						return reconcile.Result{RequeueAfter: t.Sub(now)}, nil
+					}
+					return reconcile.Result{Requeue: true}, nil
 				}
 				return reconcile.Result{}, err
 			}
@@ -513,10 +511,6 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			l.Error(err, "error during getting the members of the team in Github")
 			if t, ok := parseGitHubRateLimitReset(err.Error()); ok {
 				now := time.Now().UTC()
-				requeue := time.Duration(0)
-				if t.After(now) {
-					requeue = t.Sub(now)
-				}
 				githubTeam.Status.TeamStatus = v1.GithubTeamStateRateLimited
 				githubTeam.Status.TeamStatusError = "error during getting the members of the team in Github: " + err.Error()
 				githubTeam.Status.TeamStatusTimestamp = metav1.Now()
@@ -524,7 +518,10 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					l.Error(uerr, "error during status update")
 					return reconcile.Result{}, uerr
 				}
-				return reconcile.Result{RequeueAfter: requeue}, nil
+				if t.After(now) {
+					return reconcile.Result{RequeueAfter: t.Sub(now)}, nil
+				}
+				return reconcile.Result{Requeue: true}, nil
 			}
 			return reconcile.Result{}, err
 		}

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -22,14 +22,20 @@ func elementsMatch(listA, listB interface{}) bool {
 }
 
 // parseGitHubRateLimitReset tries to extract a reset timestamp from a GitHub rate-limit error string.
-// Expected substrings look like:
-// "API rate limit ... still exceeded until 2025-12-05 02:02:13 +0000 UTC, ..."
-// Returns the parsed time in UTC and true if found; otherwise zero time and false.
+// Handles two formats emitted by the GitHub API:
+//
+//   - Future reset:  "API rate limit ... still exceeded until 2025-12-05 02:02:13 +0000 UTC, ..."
+//     → returns the parsed future time so callers can requeue with RequeueAfter.
+//
+//   - Already reset: "... [rate limit was reset 1s ago]"
+//     → returns time.Now() so callers requeue immediately.
+//
+// Returns the reset time in UTC and true if the error is a recognisable rate-limit error;
+// otherwise returns zero time and false.
 func parseGitHubRateLimitReset(errStr string) (time.Time, bool) {
 	if errStr == "" {
 		return time.Time{}, false
 	}
-	// quick guard
 	lowered := strings.ToLower(errStr)
 	// Special-case: GitHub organization invitation rate limit errors don't include a reset timestamp.
 	// Example: "You have exceeded the organization invitation rate limit of 500 per 24 hours."
@@ -39,10 +45,18 @@ func parseGitHubRateLimitReset(errStr string) (time.Time, bool) {
 		strings.Contains(lowered, "exceeded the organization invitation rate limit") {
 		return time.Now().UTC().Add(time.Hour), true
 	}
-	if !strings.Contains(lowered, "rate limit") || !strings.Contains(lowered, "until ") {
+	if !strings.Contains(lowered, "rate limit") {
 		return time.Time{}, false
 	}
-	// Regex to capture the timestamp after "until " up to the next comma
+	// Format 2: "[rate limit was reset N ago]" — the limit has already cleared.
+	// Return now so callers requeue immediately rather than skipping the resource.
+	if strings.Contains(lowered, "was reset") && strings.Contains(lowered, "ago") {
+		return time.Now().UTC(), true
+	}
+	if !strings.Contains(lowered, "until ") {
+		return time.Time{}, false
+	}
+	// Format 1: extract the future reset timestamp after "until ".
 	// Example captured: 2025-12-05 02:02:13 +0000 UTC
 	re := regexp.MustCompile(`until\s+([^,\]]+)`)
 	m := re.FindStringSubmatch(errStr)
@@ -50,7 +64,6 @@ func parseGitHubRateLimitReset(errStr string) (time.Time, bool) {
 		return time.Time{}, false
 	}
 	ts := strings.TrimSpace(m[1])
-	// try common layout observed in error message
 	layouts := []string{
 		"2006-01-02 15:04:05 -0700 MST",
 		time.RFC3339,

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -21,16 +21,19 @@ func elementsMatch(listA, listB interface{}) bool {
 	return assert.ElementsMatch(dummyAssert{}, listA, listB)
 }
 
-// parseGitHubRateLimitReset tries to extract a reset timestamp from a GitHub rate-limit error string.
-// Handles two formats emitted by the GitHub API:
+// parseGitHubRateLimitReset tries to extract a retry-after time from a GitHub rate-limit error string.
+// Handles three cases emitted by the GitHub API:
 //
 //   - Future reset:  "API rate limit ... still exceeded until 2025-12-05 02:02:13 +0000 UTC, ..."
-//     → returns the parsed future time so callers can requeue with RequeueAfter.
+//     → returns the parsed future reset time so callers can requeue with RequeueAfter.
 //
 //   - Already reset: "... [rate limit was reset 1s ago]"
 //     → returns time.Now() so callers requeue immediately.
 //
-// Returns the reset time in UTC and true if the error is a recognisable rate-limit error;
+//   - Invitation rate limit (no timestamp): "exceeded the organization invitation rate limit …"
+//     → returns a synthetic backoff of now+1h (the API does not provide a reset time for this case).
+//
+// Returns the retry-after time in UTC and true if the error is a recognisable rate-limit error;
 // otherwise returns zero time and false.
 func parseGitHubRateLimitReset(errStr string) (time.Time, bool) {
 	if errStr == "" {

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -58,7 +58,9 @@ func parseGitHubRateLimitReset(errStr string) (time.Time, bool) {
 	}
 	// Format 1: extract the future reset timestamp after "until ".
 	// Example captured: 2025-12-05 02:02:13 +0000 UTC
-	re := regexp.MustCompile(`until\s+([^,\]]+)`)
+	// Use case-insensitive flag so the regex matches the original errStr consistently
+	// with the lowercased guard above (avoiding a mismatch if GitHub ever varies casing).
+	re := regexp.MustCompile(`(?i)until\s+([^,\]]+)`)
 	m := re.FindStringSubmatch(errStr)
 	if len(m) < 2 {
 		return time.Time{}, false

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseGitHubRateLimitReset(t *testing.T) {
+	t.Run("future reset timestamp via 'until' format", func(t *testing.T) {
+		future := time.Now().UTC().Add(5 * time.Minute)
+		errStr := "GET https://api.github.com/orgs/foo/members: 403 API rate limit exceeded for installation ID 123. still exceeded until " + future.Format("2006-01-02 15:04:05 +0000 UTC") + ", reset in 5m"
+		got, ok := parseGitHubRateLimitReset(errStr)
+		if !ok {
+			t.Fatal("expected ok=true for 'until' format, got false")
+		}
+		diff := got.Sub(future)
+		if diff < -2*time.Second || diff > 2*time.Second {
+			t.Fatalf("expected parsed time ~%v, got %v (diff %v)", future, got, diff)
+		}
+	})
+
+	t.Run("already-reset format returns now", func(t *testing.T) {
+		// This is the format that caused the bug: rate limit already cleared.
+		errStr := "GET https://github.wdf.sap.corp/api/v3/orgs/cc/members?per_page=100&role=admin: 403 API rate limit exceeded for installation ID 5668. If you reach out to GitHub Support for help, please include the request ID abc123 and timestamp 2026-06-06 23:08:46 UTC. [rate limit was reset 1s ago]"
+		before := time.Now().UTC()
+		got, ok := parseGitHubRateLimitReset(errStr)
+		after := time.Now().UTC()
+		if !ok {
+			t.Fatal("expected ok=true for 'was reset N ago' format, got false")
+		}
+		if got.Before(before.Add(-time.Second)) || got.After(after.Add(time.Second)) {
+			t.Fatalf("expected returned time to be approximately now (%v..%v), got %v", before, after, got)
+		}
+		// The returned time must not be in the future (it should be ~now, not future).
+		// Callers use t.After(now) to decide between RequeueAfter and Requeue: true.
+		// For the already-reset case t.After(now) should be false so we get Requeue: true.
+		if got.After(after.Add(time.Second)) {
+			t.Fatalf("expected already-reset time to be <= now, got %v", got)
+		}
+	})
+
+	t.Run("invitation rate limit returns conservative future backoff", func(t *testing.T) {
+		errStr := "You have exceeded the organization invitation rate limit of 500 per 24 hours."
+		before := time.Now().UTC()
+		got, ok := parseGitHubRateLimitReset(errStr)
+		if !ok {
+			t.Fatal("expected ok=true for invitation rate limit, got false")
+		}
+		if !got.After(before) {
+			t.Fatalf("expected future backoff time, got %v (before=%v)", got, before)
+		}
+	})
+
+	t.Run("non-rate-limit error returns false", func(t *testing.T) {
+		_, ok := parseGitHubRateLimitReset("404 Not Found")
+		if ok {
+			t.Fatal("expected ok=false for non-rate-limit error")
+		}
+	})
+
+	t.Run("empty string returns false", func(t *testing.T) {
+		_, ok := parseGitHubRateLimitReset("")
+		if ok {
+			t.Fatal("expected ok=false for empty string")
+		}
+	})
+}

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -31,14 +31,11 @@ func TestParseGitHubRateLimitReset(t *testing.T) {
 		if !ok {
 			t.Fatal("expected ok=true for 'was reset N ago' format, got false")
 		}
+		// The returned time must be approximately now and must not be in the future.
+		// Callers use t.After(now) to decide between RequeueAfter and Requeue: true;
+		// for the already-reset case t.After(now) must be false so we get Requeue: true.
 		if got.Before(before.Add(-time.Second)) || got.After(after.Add(time.Second)) {
 			t.Fatalf("expected returned time to be approximately now (%v..%v), got %v", before, after, got)
-		}
-		// The returned time must not be in the future (it should be ~now, not future).
-		// Callers use t.After(now) to decide between RequeueAfter and Requeue: true.
-		// For the already-reset case t.After(now) should be false so we get Requeue: true.
-		if got.After(after.Add(time.Second)) {
-			t.Fatalf("expected already-reset time to be <= now, got %v", got)
 		}
 	})
 


### PR DESCRIPTION
## Problem

GitHub occasionally returns a `403` with the message:

```
[rate limit was reset 1s ago]
```

instead of the usual `still exceeded until <timestamp>` form. This happens when the rate limit cleared between the server receiving the request and sending the response.

Two bugs caused `GithubOrganization` / `GithubTeam` resources to get permanently stuck after hitting this error:

**Bug 1 — `parseGitHubRateLimitReset` didn't recognise the "already reset" format**

The function only matched strings containing `"until "`. The `"was reset N ago"` variant returned `false`, so the caller fell through to setting `orgStatus=failed` with `return reconcile.Result{}, nil` — no requeue scheduled. The resource was silently dropped from the work queue and never reconciled again, even though the rate limit had already cleared.

Observed in production: `sci/wdf--cc` had `status.timestamp` frozen for 7+ hours after a single rate-limit response.

**Bug 2 — zero `RequeueAfter` is equivalent to no requeue**

All callers used the pattern:
```go
requeue := time.Duration(0)
if t.After(now) {
    requeue = t.Sub(now)
}
return reconcile.Result{RequeueAfter: requeue}, nil
```
A zero `RequeueAfter` in controller-runtime does not requeue the resource. This meant even when the reset time was correctly parsed but already in the past, the resource would be dropped.

## Fix

- **`parseGitHubRateLimitReset`**: detect `"was reset … ago"` and return `time.Now()` so callers know the limit has already cleared.
- **All 7 call sites** (3 in org controller, 4 in team controller): replace the `requeue=0` pattern with an explicit branch — `RequeueAfter: t.Sub(now)` when the reset is still in the future, `Requeue: true` when it has already passed.

## Test plan

- [x] New unit tests in `utils_test.go` cover the "already reset" format, the "future until" format, the invitation rate limit special case, non-rate-limit errors, and empty input — all pass
- [x] `make build` compiles cleanly
- [x] Verified the production resource (`sci/wdf--cc`) was stuck for 7h and recovered immediately after manually triggering a reconcile via annotation