### PR TITLE
chore(dashboard): rename second-row panels to show current status

### DIFF
--- a/dashboards/repoguard-status-ops-perses.json
+++ b/dashboards/repoguard-status-ops-perses.json
@@ -161,7 +161,7 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "🏢 Organizations Needing Attention"
+            "name": "🏢 Organizations • Current Status"
           },
           "plugin": {
             "kind": "Table",
@@ -193,7 +193,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "last_over_time((sum by (github, organization, status) (repo_guard_githuborganization_status{github=~\"$github\", organization=~\"$org\", status=~\"failed|ratelimited|pending\"} == 1))[$__range:])"
+                    "query": "sum by (github, organization, status) (repo_guard_githuborganization_status{github=~\"$github\", organization=~\"$org\", status=~\"failed|ratelimited|pending\"} == 1)"
                   }
                 }
               }
@@ -412,7 +412,7 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "👥 Teams Needing Attention"
+            "name": "👥 Teams • Current Status"
           },
           "plugin": {
             "kind": "Table",
@@ -444,7 +444,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "last_over_time((sum by (organization, team, status) (repo_guard_githubteam_status{status=~\"failed|ratelimited|pending\", organization=~\"$org\", team=~\"$team\"} == 1))[$__range:])"
+                    "query": "sum by (organization, team, status) (repo_guard_githubteam_status{status=~\"failed|ratelimited|pending\", organization=~\"$org\", team=~\"$team\"} == 1)"
                   }
                 }
               }

--- a/dashboards/repoguard-status-ops-plutono.json
+++ b/dashboards/repoguard-status-ops-plutono.json
@@ -145,7 +145,7 @@
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
       "id": 200,
       "panels": [],
-      "title": "⚠️ Current Failing & Pending Resources",
+      "title": "⚠️ Current Status",
       "type": "row"
     },
     {
@@ -165,7 +165,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
       "id": 10,
       "options": { "footer": { "show": false }, "showHeader": true },
-      "title": "🏢 Organizations Needing Attention",
+      "title": "🏢 Organizations • Current Status",
       "type": "table",
       "targets": [
         { "expr": "sum by (github, organization, status) (repo_guard_githuborganization_status{github=~\"$github\", organization=~\"$org\", status=~\"failed|ratelimited|pending\"} == 1)", "format": "table", "instant": true, "refId": "A" }
@@ -176,7 +176,7 @@
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
       "id": 11,
       "options": { "footer": { "show": false }, "showHeader": true },
-      "title": "👥 Teams Needing Attention",
+      "title": "👥 Teams • Current Status",
       "type": "table",
       "targets": [
         { "expr": "sum by (organization, team, status) (repo_guard_githubteam_status{status=~\"failed|ratelimited|pending\", organization=~\"$org\", team=~\"$team\"} == 1)", "format": "table", "instant": true, "refId": "A" }


### PR DESCRIPTION
## Summary

- Rename **"Organizations Needing Attention"** → **"Organizations • Current Status"** in both Plutono and Perses dashboards
- Rename **"Teams Needing Attention"** → **"Teams • Current Status"** in both dashboards
- Update the section row header from **"Current Failing & Pending Resources"** → **"Current Status"** (Plutono)
- Replace `last_over_time(...[$__range:])` queries with plain instant queries in the Perses dashboard so the tables reflect live state rather than the last known value over the time range

## Test plan

- [ ] Verify panel titles in Plutono/Grafana match the new names
- [ ] Verify panel titles in Perses match the new names
- [ ] Confirm the Perses table panels show live data (empty when no issues, populated when failures/ratelimits are active)