### PR TITLE
feat(ci): delegate lint and test to shared workflows; replace release-cut logic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
           HELM_VERSION: v3.21.2
           KUBECTL_VERSION: v1.32.5
         run: |
+          set -o pipefail
           curl -sf "https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh" | TAG="${K3D_VERSION}" bash
           curl -sf "https://raw.githubusercontent.com/helm/helm/${HELM_VERSION}/scripts/get-helm-3" | DESIRED_VERSION="${HELM_VERSION}" bash
           curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,9 @@ jobs:
           curl -sf "https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh" | TAG="${K3D_VERSION}" bash
           curl -sf "https://raw.githubusercontent.com/helm/helm/${HELM_VERSION}/scripts/get-helm-3" | DESIRED_VERSION="${HELM_VERSION}" bash
           curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+          curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
+          echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
+          rm kubectl.sha256
           chmod +x kubectl
           sudo mv kubectl /usr/local/bin/kubectl
           kubectl version --client

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,9 +44,9 @@ jobs:
           HELM_VERSION: v3.21.2
           KUBECTL_VERSION: v1.32.5
         run: |
-          curl -s "https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh" | TAG="${K3D_VERSION}" bash
-          curl -s "https://raw.githubusercontent.com/helm/helm/${HELM_VERSION}/scripts/get-helm-3" | DESIRED_VERSION="${HELM_VERSION}" bash
-          curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+          curl -sf "https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh" | TAG="${K3D_VERSION}" bash
+          curl -sf "https://raw.githubusercontent.com/helm/helm/${HELM_VERSION}/scripts/get-helm-3" | DESIRED_VERSION="${HELM_VERSION}" bash
+          curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
           chmod +x kubectl
           sudo mv kubectl /usr/local/bin/kubectl
           kubectl version --client

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,81 +12,47 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-      - name: golangci-lint
-        run: make lint
+    uses: cloudoperators/common/.github/workflows/shared-go-lint.yaml@main
 
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-      - name: Install dependencies
-        run: go mod download
-      - name: Run Controller Tests
-        # GITHUB_MOCK=true (the default) means no real GitHub credentials are
-        # needed.  All GitHub API calls are served by an in-process httptest
-        # server.  Secrets are intentionally absent from this job so that forks
-        # and external PRs can pass CI without org membership.
-        env:
-          GITHUB_MOCK: "true"
-          TEST_LDAP_GROUP_PROVIDER_HOST: "ldap://localhost:389"
-          TEST_LDAP_GROUP_PROVIDER_BASE_DN: "DC=ad,DC=global"
-          TEST_LDAP_GROUP_PROVIDER_BIND_DN: "CN=ldap-service,CN=Users,DC=ad,DC=global"
-          TEST_LDAP_GROUP_PROVIDER_BIND_PW: randompassword
-        run: make controller-test
+    uses: cloudoperators/common/.github/workflows/shared-go-test.yaml@main
+    with:
+      test-target: controller-test
+      extra-env: |
+        GITHUB_MOCK=true
+        TEST_LDAP_GROUP_PROVIDER_HOST=ldap://localhost:389
+        TEST_LDAP_GROUP_PROVIDER_BASE_DN=DC=ad,DC=global
+        TEST_LDAP_GROUP_PROVIDER_BIND_DN=CN=ldap-service,CN=Users,DC=ad,DC=global
+        TEST_LDAP_GROUP_PROVIDER_BIND_PW=randompassword
 
   e2e:
     needs: test
     runs-on: ubuntu-latest
     environment: e2e
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: go.mod
           cache: true
       - name: Install dependencies
         run: go mod download
       - name: Setup E2E Prerequisites (k3d, kubectl, helm, jq)
         run: |
-          # Install k3d
           curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
-
-          # Install Helm
           curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-
-          # Install kubectl
           curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
           chmod +x kubectl
           sudo mv kubectl /usr/local/bin/kubectl
-
-          # kubectl, helm, and jq should now be in /usr/local/bin
           kubectl version --client
           helm version
           jq --version
-
           echo "/usr/local/bin" >> $GITHUB_PATH
       - name: Run E2E Tests (mock GitHub)
-        # USE_MOCK_GITHUB=true (the default) deploys an in-cluster GitHub API mock
-        # server instead of calling the real GitHub API.  No real GitHub secrets
-        # are needed — forks and external PRs can run the full e2e suite.
         env:
           USE_MOCK_GITHUB: "true"
-        run: |
-          make e2e
+        run: make e2e
       - name: Teardown E2E cluster
         if: always()
         run: make e2e-down

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,16 +39,20 @@ jobs:
       - name: Install dependencies
         run: go mod download
       - name: Setup E2E Prerequisites (k3d, kubectl, helm, jq)
+        env:
+          K3D_VERSION: v5.9.0
+          HELM_VERSION: v3.21.2
+          KUBECTL_VERSION: v1.32.5
         run: |
-          curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
-          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -s "https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh" | TAG="${K3D_VERSION}" bash
+          curl -s "https://raw.githubusercontent.com/helm/helm/${HELM_VERSION}/scripts/get-helm-3" | DESIRED_VERSION="${HELM_VERSION}" bash
+          curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
           chmod +x kubectl
           sudo mv kubectl /usr/local/bin/kubectl
           kubectl version --client
           helm version
           jq --version
-          echo "/usr/local/bin" >> $GITHUB_PATH
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
       - name: Run E2E Tests (mock GitHub)
         env:
           USE_MOCK_GITHUB: "true"

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -24,3 +24,5 @@ jobs:
       environment: release
     secrets:
       release-token: ${{ secrets.RELEASE_GH_TOKEN_PR }}
+      dispatch-app-id: ${{ secrets.CLOUDOPERATOR_APP_ID }}
+      dispatch-app-private-key: ${{ secrets.CLOUDOPERATOR_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -21,5 +21,6 @@ jobs:
       bump-make-version: true
       dispatch-greenhouse-extensions: true
       plugin-name: repo-guard
+      environment: release
     secrets:
       release-token: ${{ secrets.RELEASE_GH_TOKEN_PR }}

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -14,77 +14,12 @@ on:
 
 jobs:
   cut-release:
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      contents: write
-      pull-requests: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Compute new version
-        id: version
-        run: |
-          CURRENT=$(grep '^version:' charts/repo-guard/Chart.yaml | awk '{print $2}')
-          MAJOR=$(echo "$CURRENT" | cut -d. -f1)
-          MINOR=$(echo "$CURRENT" | cut -d. -f2)
-          PATCH=$(echo "$CURRENT" | cut -d. -f3)
-          case "${{ github.event.inputs.bump }}" in
-            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
-            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
-            patch) PATCH=$((PATCH + 1)) ;;
-          esac
-          NEW_VERSION="$MAJOR.$MINOR.$PATCH"
-          echo "Current version: $CURRENT → New version: $NEW_VERSION"
-          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Update versions in Chart.yaml and Makefile
-        run: |
-          NEW_VERSION=${{ steps.version.outputs.new_version }}
-          sed -i "s/^version: .*/version: $NEW_VERSION/" charts/repo-guard/Chart.yaml
-          sed -i "s/^appVersion: .*/appVersion: \"$NEW_VERSION\"/" charts/repo-guard/Chart.yaml
-          sed -i "s|^IMG ?= \(.*\):.*|IMG ?= \1:$NEW_VERSION|" Makefile
-
-      - name: Create and auto-merge Pull Request
-        id: pr
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN_PR }}
-        run: |
-          NEW_VERSION=${{ steps.version.outputs.new_version }}
-          BRANCH_NAME="release-$NEW_VERSION"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git checkout -b "$BRANCH_NAME"
-          git add charts/repo-guard/Chart.yaml Makefile
-          git commit -s -m "chore: prepare release $NEW_VERSION"
-          git push origin "$BRANCH_NAME"
-
-          PR_URL=$(gh pr create \
-            --title "chore: prepare release $NEW_VERSION" \
-            --body "Automated version bump to $NEW_VERSION for release." \
-            --head "$BRANCH_NAME" \
-            --base main)
-
-          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
-          echo "branch=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
-
-          gh pr merge "$PR_URL" --squash --admin
-
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_GH_TOKEN_PR }}
-        run: |
-          NEW_VERSION=${{ steps.version.outputs.new_version }}
-          # Fetch the latest main so the tag points at the merge commit
-          git fetch origin main
-          git checkout main
-          git pull origin main
-
-          gh release create "v$NEW_VERSION" \
-            --title "v$NEW_VERSION" \
-            --generate-notes \
-            --target main
+    uses: cloudoperators/common/.github/workflows/shared-release.yaml@main
+    with:
+      bump: ${{ inputs.bump }}
+      chart-path: charts/repo-guard/Chart.yaml
+      bump-make-version: true
+      dispatch-greenhouse-extensions: true
+      plugin-name: repo-guard
+    secrets:
+      release-token: ${{ secrets.RELEASE_GH_TOKEN_PR }}

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -15,6 +15,8 @@ on:
 jobs:
   cut-release:
     uses: cloudoperators/common/.github/workflows/shared-release.yaml@main
+    permissions:
+      contents: write
     with:
       bump: ${{ inputs.bump }}
       chart-path: charts/repo-guard/Chart.yaml

--- a/.github/workflows/release-cut.yaml
+++ b/.github/workflows/release-cut.yaml
@@ -20,6 +20,7 @@ jobs:
     with:
       bump: ${{ inputs.bump }}
       chart-path: charts/repo-guard/Chart.yaml
+      makefile-path: Makefile
       bump-make-version: true
       dispatch-greenhouse-extensions: true
       plugin-name: repo-guard


### PR DESCRIPTION
## Summary

Migrates `ci.yaml` and `release-cut.yaml` to consume reusable workflows from `cloudoperators/common` as part of [cloudoperators/common#2086](https://github.com/cloudoperators/greenhouse/issues/2086).

### ci.yaml

| Job | Before | After |
|---|---|---|
| `lint` | Inline `actions/checkout` + `actions/setup-go` + `make lint` | `shared-go-lint.yaml@main` |
| `test` | Inline checkout + setup-go + `go mod download` + `make controller-test` | `shared-go-test.yaml@main` with `test-target: controller-test` and all required env vars |
| `e2e` | Inline (unchanged) | Inline — retained as-is; uses repo-guard-specific k3d + mock-GitHub setup that does not map to the greenhouse KinD composite |

### release-cut.yaml

Replaces all inline semver computation, file patching, PR creation, and release creation with a single call to `shared-release.yaml@main`. Adds `dispatch-greenhouse-extensions: true` so a `plugin-release` event is sent to `cloudoperators/greenhouse-extensions` after each release. Passes `environment: release` through the shared workflow's `environment` input so protection rules and environment-scoped secrets are preserved.

## Changes from review (701fafe)

- Added `environment: release` via the `shared-release.yaml` `environment` input, restoring the protection rule gating that existed in the original inline workflow.

## Dependencies

Requires `cloudoperators/common#65` to be merged before this workflow will resolve correctly in CI.

## Test plan

- [ ] Trigger a PR to verify `lint` and `test` jobs resolve from the shared workflow
- [ ] Run `release-cut` workflow manually (dry-run on a non-main branch) to verify version bump logic and environment gating