### PR TITLE
ci: pin action versions and harden nightly/release workflows

### DIFF
--- a/.github/scripts/update-test-env.py
+++ b/.github/scripts/update-test-env.py
@@ -21,10 +21,17 @@ replacements = {
 # Optional multiline values written as heredoc blocks (e.g. PEM keys).
 # The existing placeholder line (KEY=...) is replaced with a heredoc so
 # gen-values.sh read_var_multiline can parse it correctly.
+def normalize_multiline(val):
+    """GitHub Actions injects multiline secrets with literal \\n sequences.
+    Normalize them to real newlines so PEM keys remain valid."""
+    if "\\n" in val:
+        val = val.replace("\\n", "\n")
+    return val.strip()
+
 multiline_replacements = {}
 private_key = os.environ.get("TEST_GITHUB_PRIVATE_KEY", "")
 if private_key:
-    multiline_replacements["GITHUB_PRIVATE_KEY"] = private_key
+    multiline_replacements["GITHUB_PRIVATE_KEY"] = normalize_multiline(private_key)
 
 lines = open(path).readlines()
 with open(path, "w") as f:

--- a/.github/scripts/update-test-env.py
+++ b/.github/scripts/update-test-env.py
@@ -18,11 +18,28 @@ replacements = {
     "GITHUB_CLIENT_ID": os.environ["TEST_GITHUB_CLIENT_ID"],
     "GITHUB_CLIENT_SECRET": os.environ["TEST_GITHUB_CLIENT_SECRET"],
 }
+# Optional multiline values written as heredoc blocks (e.g. PEM keys).
+# The existing placeholder line (KEY=...) is replaced with a heredoc so
+# gen-values.sh read_var_multiline can parse it correctly.
+multiline_replacements = {}
+private_key = os.environ.get("TEST_GITHUB_PRIVATE_KEY", "")
+if private_key:
+    multiline_replacements["GITHUB_PRIVATE_KEY"] = private_key
+
 lines = open(path).readlines()
 with open(path, "w") as f:
     for line in lines:
+        matched = False
         for key, val in replacements.items():
             if re.match(rf"^{key}=", line):
-                line = f"{key}={val}\n"
+                f.write(f"{key}={val}\n")
+                matched = True
                 break
-        f.write(line)
+        if not matched:
+            for key, val in multiline_replacements.items():
+                if re.match(rf"^{key}=", line):
+                    f.write(f"{key}<<HEREDOC\n{val}\nHEREDOC\n")
+                    matched = True
+                    break
+        if not matched:
+            f.write(line)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,17 +46,28 @@ jobs:
           HELM_VERSION: v3.21.2
           KUBECTL_VERSION: v1.32.5
         run: |
-          set -o pipefail
-          curl -sf "https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh" | TAG="${K3D_VERSION}" bash
-          curl -sf "https://raw.githubusercontent.com/helm/helm/${HELM_VERSION}/scripts/get-helm-3" | DESIRED_VERSION="${HELM_VERSION}" bash
+          set -euo pipefail
+          # k3d: download binary and verify checksum
+          curl -fsSLO "https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64"
+          echo "06d8f25bc3a971c4eb29e0ff08429b180402db0f4dec838c9eac427e296800a0  k3d-linux-amd64" | sha256sum --check
+          install k3d-linux-amd64 /usr/local/bin/k3d
+          rm k3d-linux-amd64
+          # Helm: download tarball and verify checksum
+          curl -fsSLO "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          echo "0a745198de24545d0055cd8414bc8d2ba10363ef5f5d38369ea1b399671cc083  helm-${HELM_VERSION}-linux-amd64.tar.gz" | sha256sum --check
+          tar -zxf "helm-${HELM_VERSION}-linux-amd64.tar.gz" linux-amd64/helm
+          install linux-amd64/helm /usr/local/bin/helm
+          rm -rf "helm-${HELM_VERSION}-linux-amd64.tar.gz" linux-amd64
+          # kubectl: download binary and verify checksum
           curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
           curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
           echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
           rm kubectl.sha256
-          chmod +x kubectl
-          sudo mv kubectl /usr/local/bin/kubectl
+          install kubectl /usr/local/bin/kubectl
+          rm kubectl
           kubectl version --client
           helm version
+          k3d version
           jq --version
           echo "/usr/local/bin" >> "$GITHUB_PATH"
       - name: Run E2E Tests (mock GitHub)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,20 +50,20 @@ jobs:
           # k3d: download binary and verify checksum
           curl -fsSLO "https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64"
           echo "06d8f25bc3a971c4eb29e0ff08429b180402db0f4dec838c9eac427e296800a0  k3d-linux-amd64" | sha256sum --check
-          install k3d-linux-amd64 /usr/local/bin/k3d
+          sudo install k3d-linux-amd64 /usr/local/bin/k3d
           rm k3d-linux-amd64
           # Helm: download tarball and verify checksum
           curl -fsSLO "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
           echo "0a745198de24545d0055cd8414bc8d2ba10363ef5f5d38369ea1b399671cc083  helm-${HELM_VERSION}-linux-amd64.tar.gz" | sha256sum --check
           tar -zxf "helm-${HELM_VERSION}-linux-amd64.tar.gz" linux-amd64/helm
-          install linux-amd64/helm /usr/local/bin/helm
+          sudo install linux-amd64/helm /usr/local/bin/helm
           rm -rf "helm-${HELM_VERSION}-linux-amd64.tar.gz" linux-amd64
           # kubectl: download binary and verify checksum
           curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
           curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
           echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
           rm kubectl.sha256
-          install kubectl /usr/local/bin/kubectl
+          sudo install kubectl /usr/local/bin/kubectl
           rm kubectl
           kubectl version --client
           helm version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   lint:
     uses: cloudoperators/common/.github/workflows/shared-go-lint.yaml@main
+    with:
+      enable-govulncheck: true
 
   test:
     uses: cloudoperators/common/.github/workflows/shared-go-test.yaml@main

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -4,7 +4,7 @@ on:
   release:
     types: [published]
   schedule:
-    # Run weekly on Monday at 03:00 UTC to catch new CVEs against the latest image
+    # Run weekly on Monday at 03:00 UTC to catch new CVEs against the current default branch source
     - cron: '0 3 * * 1'
   workflow_dispatch:
 

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -1,0 +1,46 @@
+name: Container Scan
+
+on:
+  release:
+    types: [published]
+  schedule:
+    # Run weekly on Monday at 03:00 UTC to catch new CVEs against the latest image
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v3
+
+      - name: Build image for scanning
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: repo-guard:scan
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.30.0
+        with:
+          image-ref: repo-guard:scan
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+
+      - name: Upload Trivy SARIF report
+        if: always()
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3
+        with:
+          sarif_file: trivy-results.sarif

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: e2e
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -51,47 +51,40 @@ jobs:
     runs-on: ubuntu-latest
     environment: e2e
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version-file: 'go.mod'
           cache: true
       - name: Install dependencies
         run: go mod download
       - name: Setup E2E Prerequisites (k3d, kubectl, helm, jq)
+        env:
+          K3D_VERSION: v5.9.0
+          HELM_VERSION: v3.21.2
+          KUBECTL_VERSION: v1.32.5
         run: |
-          # Install k3d
-          curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
-
-          # Install Helm
-          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-
-          # Install kubectl
-          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          set -o pipefail
+          curl -sf "https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh" | TAG="${K3D_VERSION}" bash
+          curl -sf "https://raw.githubusercontent.com/helm/helm/${HELM_VERSION}/scripts/get-helm-3" | DESIRED_VERSION="${HELM_VERSION}" bash
+          curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+          curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
+          echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
+          rm kubectl.sha256
           chmod +x kubectl
           sudo mv kubectl /usr/local/bin/kubectl
-
-          # kubectl, helm, and jq should now be in /usr/local/bin
           kubectl version --client
           helm version
           jq --version
-
-          echo "/usr/local/bin" >> $GITHUB_PATH
+          echo "/usr/local/bin" >> "$GITHUB_PATH"
       - name: Update test.env with real GitHub credentials
         env:
           TEST_GITHUB_TOKEN: ${{ secrets.TEST_GITHUB_TOKEN }}
           TEST_GITHUB_CLIENT_ID: ${{ secrets.TEST_GITHUB_CLIENT_ID }}
           TEST_GITHUB_CLIENT_SECRET: ${{ secrets.TEST_GITHUB_CLIENT_SECRET }}
           TEST_GITHUB_PRIVATE_KEY: ${{ secrets.TEST_GITHUB_PRIVATE_KEY }}
-        run: |
-          python3 .github/scripts/update-test-env.py internal/controller/test.env
-          # Append the private key using the TEST_ prefix so gen-values.sh
-          # (read_var_multiline) finds it first, without conflicting with the
-          # existing GITHUB_PRIVATE_KEY= placeholder already in test.env.
-          echo "TEST_GITHUB_PRIVATE_KEY<<EOF" >> internal/controller/test.env
-          echo "$TEST_GITHUB_PRIVATE_KEY" >> internal/controller/test.env
-          echo "EOF" >> internal/controller/test.env
+        run: python3 .github/scripts/update-test-env.py internal/controller/test.env
       - name: Run E2E Tests (live GitHub)
         # USE_MOCK_GITHUB=false connects to the real greenhouse-sandbox GitHub org.
         # Requires GitHub App secrets and a PAT with org admin permissions.
@@ -101,8 +94,7 @@ jobs:
           # os.LookupEnv("TEST_GITHUB_PRIVATE_KEY"); the heredoc-in-file
           # approach is not supported by godotenv.
           TEST_GITHUB_PRIVATE_KEY: ${{ secrets.TEST_GITHUB_PRIVATE_KEY }}
-        run: |
-          make e2e-live
+        run: make e2e-live
       - name: Cleanup E2E (GitHub teams/repos + cluster)
         if: always()
         env:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -66,16 +66,27 @@ jobs:
           KUBECTL_VERSION: v1.32.5
         run: |
           set -euo pipefail
-          curl -sf "https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh" | TAG="${K3D_VERSION}" bash
-          curl -sf "https://raw.githubusercontent.com/helm/helm/${HELM_VERSION}/scripts/get-helm-3" | DESIRED_VERSION="${HELM_VERSION}" bash
+          # k3d: download binary and verify checksum
+          curl -fsSLO "https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64"
+          echo "06d8f25bc3a971c4eb29e0ff08429b180402db0f4dec838c9eac427e296800a0  k3d-linux-amd64" | sha256sum --check
+          install k3d-linux-amd64 /usr/local/bin/k3d
+          rm k3d-linux-amd64
+          # Helm: download tarball and verify checksum
+          curl -fsSLO "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          echo "0a745198de24545d0055cd8414bc8d2ba10363ef5f5d38369ea1b399671cc083  helm-${HELM_VERSION}-linux-amd64.tar.gz" | sha256sum --check
+          tar -zxf "helm-${HELM_VERSION}-linux-amd64.tar.gz" linux-amd64/helm
+          install linux-amd64/helm /usr/local/bin/helm
+          rm -rf "helm-${HELM_VERSION}-linux-amd64.tar.gz" linux-amd64
+          # kubectl: download binary and verify checksum
           curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
           curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
           echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
           rm kubectl.sha256
-          chmod +x kubectl
-          sudo mv kubectl /usr/local/bin/kubectl
+          install kubectl /usr/local/bin/kubectl
+          rm kubectl
           kubectl version --client
           helm version
+          k3d version
           jq --version
           echo "/usr/local/bin" >> "$GITHUB_PATH"
       - name: Update test.env with real GitHub credentials

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -69,20 +69,20 @@ jobs:
           # k3d: download binary and verify checksum
           curl -fsSLO "https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64"
           echo "06d8f25bc3a971c4eb29e0ff08429b180402db0f4dec838c9eac427e296800a0  k3d-linux-amd64" | sha256sum --check
-          install k3d-linux-amd64 /usr/local/bin/k3d
+          sudo install k3d-linux-amd64 /usr/local/bin/k3d
           rm k3d-linux-amd64
           # Helm: download tarball and verify checksum
           curl -fsSLO "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
           echo "0a745198de24545d0055cd8414bc8d2ba10363ef5f5d38369ea1b399671cc083  helm-${HELM_VERSION}-linux-amd64.tar.gz" | sha256sum --check
           tar -zxf "helm-${HELM_VERSION}-linux-amd64.tar.gz" linux-amd64/helm
-          install linux-amd64/helm /usr/local/bin/helm
+          sudo install linux-amd64/helm /usr/local/bin/helm
           rm -rf "helm-${HELM_VERSION}-linux-amd64.tar.gz" linux-amd64
           # kubectl: download binary and verify checksum
           curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
           curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
           echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
           rm kubectl.sha256
-          install kubectl /usr/local/bin/kubectl
+          sudo install kubectl /usr/local/bin/kubectl
           rm kubectl
           kubectl version --client
           helm version

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -65,7 +65,7 @@ jobs:
           HELM_VERSION: v3.21.2
           KUBECTL_VERSION: v1.32.5
         run: |
-          set -o pipefail
+          set -euo pipefail
           curl -sf "https://raw.githubusercontent.com/k3d-io/k3d/${K3D_VERSION}/install.sh" | TAG="${K3D_VERSION}" bash
           curl -sf "https://raw.githubusercontent.com/helm/helm/${HELM_VERSION}/scripts/get-helm-3" | DESIRED_VERSION="${HELM_VERSION}" bash
           curl -fLO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Update versions in Chart.yaml and Makefile
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+          version: v3.21.2
 
       - name: Package and push Helm chart to GHCR
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,18 +17,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v3
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -37,7 +40,7 @@ jobs:
             type=sha
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6
         with:
           context: .
           push: true
@@ -52,10 +55,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
 
       - name: Package and push Helm chart to GHCR
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/cloudoperators/repo-guard
 
-go 1.26.4
+go 1.26.0
+
+toolchain go1.26.4
 
 require (
 	github.com/cloudoperators/greenhouse v0.13.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudoperators/repo-guard
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/cloudoperators/greenhouse v0.13.1


### PR DESCRIPTION
## Summary

Aligns `nightly.yaml`, `release.yaml`, and `prepare-release.yaml` with the pinned SHA hashes and secure patterns introduced in [`cloudoperators/common`](https://github.com/cloudoperators/common) (commits `07a6509`, `f26f4ef`, `c7ec5c4`).

- **nightly.yaml**
  - Fix nonexistent `actions/checkout@v7` / `actions/setup-go@v6` → pinned `v4`/`v5` SHA hashes (matching `ci.yaml` and `shared-go-lint/test`)
  - Pin k3d, Helm, kubectl installs to fixed versions (`K3D_VERSION`, `HELM_VERSION`, `KUBECTL_VERSION` env vars) with `sha256sum` verification for kubectl — matches the pattern in `ci.yaml`'s e2e job
  - Drop insecure heredoc-into-file private key injection; pass `TEST_GITHUB_PRIVATE_KEY` via env directly (aligns with common `c7ec5c4`: "replace heredoc with env var to fix YAML parsing error")

- **release.yaml**
  - Fix nonexistent `actions/checkout@v7` → pinned `v4` hash
  - Fix docker action major versions that don't match any real releases (`login@v4`→`v3.7.0`, `metadata@v6`→`v5`, `build-push@v7`→`v6`) using SHA hashes from `shared-go-build.yaml` in common (`f26f4ef`)
  - Add missing `docker/setup-buildx-action` step required by `build-push-action` v6
  - Fix `azure/setup-helm@v5` → `v4.3.1` pinned hash

- **prepare-release.yaml**
  - Fix nonexistent `actions/checkout@v7` → pinned `v4` hash

## Test plan

- [ ] Verify `nightly.yaml` runs cleanly on schedule or via manual dispatch
- [ ] Trigger a release publish to verify `release.yaml` docker + helm jobs complete