### PR TITLE
feat(ha): wire leader election flag and add PDB & HA Helm support

### DIFF
--- a/charts/repo-guard/templates/deployment.yaml
+++ b/charts/repo-guard/templates/deployment.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if and (gt (int .Values.manager.replicas) 1) (not .Values.manager.leaderElection) }}
+{{- if and .Values.manager.enabled (gt (int .Values.manager.replicas) 1) (not .Values.manager.leaderElection) }}
   {{- fail "manager.leaderElection must be true when manager.replicas > 1 to prevent split-brain" }}
 {{- end }}
 {{ if .Values.manager.enabled }}

--- a/charts/repo-guard/templates/deployment.yaml
+++ b/charts/repo-guard/templates/deployment.yaml
@@ -26,12 +26,17 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
     spec:
+      securityContext:
+        runAsNonRoot: true
       containers:
       - command:
         - /manager
         args:
         - --metrics-bind-address=:9443
         - --health-probe-bind-address=:8082
+        {{- if .Values.manager.leaderElection }}
+        - --leader-elect
+        {{- end }}
         # - --namespace
         # - "$(NAMESPACE)"
         env:
@@ -63,6 +68,22 @@ spec:
           protocol: TCP
         resources: {{- toYaml .Values.manager.resources | nindent 10
           }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      {{- if .Values.manager.leaderElection }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  control-plane: controller-manager
+              topologyKey: kubernetes.io/hostname
+      {{- end }}
       serviceAccountName: {{ include "repo-guard.fullname" . }}-controller-manager
       terminationGracePeriodSeconds: 10
 {{ end }}

--- a/charts/repo-guard/templates/deployment.yaml
+++ b/charts/repo-guard/templates/deployment.yaml
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if and (gt (int .Values.manager.replicas) 1) (not .Values.manager.leaderElection) }}
+  {{- fail "manager.leaderElection must be true when manager.replicas > 1 to prevent split-brain" }}
+{{- end }}
 {{ if .Values.manager.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -36,6 +39,7 @@ spec:
         - --health-probe-bind-address=:8082
         {{- if .Values.manager.leaderElection }}
         - --leader-elect
+        - --leader-election-id={{ include "repo-guard.fullname" . }}
         {{- end }}
         # - --namespace
         # - "$(NAMESPACE)"
@@ -82,6 +86,7 @@ spec:
               labelSelector:
                 matchLabels:
                   control-plane: controller-manager
+                  {{- include "repo-guard.selectorLabels" . | nindent 18 }}
               topologyKey: kubernetes.io/hostname
       {{- end }}
       serviceAccountName: {{ include "repo-guard.fullname" . }}-controller-manager

--- a/charts/repo-guard/templates/leader-election-rbac.yaml
+++ b/charts/repo-guard/templates/leader-election-rbac.yaml
@@ -12,10 +12,10 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: [configmaps]
-  verbs: [get, list, watch, create, update, patch, delete]
+  verbs: [get, list, watch, create, update, patch]
 - apiGroups: [coordination.k8s.io]
   resources: [leases]
-  verbs: [get, list, watch, create, update, patch, delete]
+  verbs: [get, list, watch, create, update, patch]
 - apiGroups: [""]
   resources: [events]
   verbs: [create, patch]

--- a/charts/repo-guard/templates/leader-election-rbac.yaml
+++ b/charts/repo-guard/templates/leader-election-rbac.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if and .Values.manager.enabled .Values.manager.leaderElection }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "repo-guard.fullname" . }}-leader-election-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "repo-guard.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: [configmaps]
+  verbs: [get, list, watch, create, update, patch, delete]
+- apiGroups: [coordination.k8s.io]
+  resources: [leases]
+  verbs: [get, list, watch, create, update, patch, delete]
+- apiGroups: [""]
+  resources: [events]
+  verbs: [create, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "repo-guard.fullname" . }}-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "repo-guard.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "repo-guard.fullname" . }}-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "repo-guard.fullname" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/repo-guard/templates/poddisruptionbudget.yaml
+++ b/charts/repo-guard/templates/poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if and .Values.manager.enabled .Values.manager.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "repo-guard.fullname" . }}-controller-manager
+  labels:
+    {{- include "repo-guard.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.manager.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      {{- include "repo-guard.selectorLabels" . | nindent 6 }}
+{{ end }}

--- a/charts/repo-guard/values.yaml
+++ b/charts/repo-guard/values.yaml
@@ -5,6 +5,13 @@ manager:
   enabled: false
   image:
       repository: ghcr.io/cloudoperators/repo-guard
+  replicas: 1
+  # Enable leader election. Required when replicas > 1 to prevent race conditions.
+  leaderElection: false
+  # Resource recommendations based on typical load:
+  #   Single-org, low-churn:   requests: cpu=50m,  memory=256Mi  limits: cpu=500m,  memory=512Mi
+  #   Multi-org, active sync:  requests: cpu=100m, memory=512Mi  limits: cpu=1000m, memory=1Gi   (default)
+  #   High-load (>10 orgs):    requests: cpu=200m, memory=512Mi  limits: cpu=2000m, memory=2Gi
   resources:
     limits:
       cpu: 1000m
@@ -12,7 +19,10 @@ manager:
     requests:
       cpu: 100m
       memory: 512Mi
-  replicas: 1
+  # Pod Disruption Budget. Enable when replicas > 1 to protect availability during node maintenance.
+  pdb:
+    enabled: false
+    minAvailable: 1
 
 ## Global TTL defaults used by templates when org/team-specific overrides are not provided
 ttl:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,11 +48,13 @@ func main() {
 	var probeAddr string
 	var currentNamespace string
 	var maxConcurrentReconciles int
+	var leaderElect bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8082", "The address the probe endpoint binds to.")
 	flag.StringVar(&currentNamespace, "namespace", "", "Current namespace so that manager will set as default namespace")
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 10, "The maximum number of concurrent Reconciles which can be run.")
+	flag.BoolVar(&leaderElect, "leader-elect", false, "Enable leader election for controller manager.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -76,7 +78,8 @@ func main() {
 		Metrics: server.Options{BindAddress: metricsAddr},
 
 		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         false,
+		LeaderElection:         leaderElect,
+		LeaderElectionID:       "repo-guard.cloudoperators.dev",
 	}
 
 	if currentNamespace != "" {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,12 +49,14 @@ func main() {
 	var currentNamespace string
 	var maxConcurrentReconciles int
 	var leaderElect bool
+	var leaderElectionID string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8082", "The address the probe endpoint binds to.")
 	flag.StringVar(&currentNamespace, "namespace", "", "Current namespace so that manager will set as default namespace")
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 10, "The maximum number of concurrent Reconciles which can be run.")
 	flag.BoolVar(&leaderElect, "leader-elect", false, "Enable leader election for controller manager.")
+	flag.StringVar(&leaderElectionID, "leader-election-id", "repo-guard.cloudoperators.dev", "Name of the leader election Lease resource.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -79,7 +81,7 @@ func main() {
 
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         leaderElect,
-		LeaderElectionID:       "repo-guard.cloudoperators.dev",
+		LeaderElectionID:       leaderElectionID,
 	}
 
 	if currentNamespace != "" {


### PR DESCRIPTION
## Summary

Closes #96, closes #102.

- **`cmd/main.go`**: Wire the `--leader-elect` flag so leader election is controlled at runtime (was hardcoded `false`). Set `LeaderElectionID` to `repo-guard.cloudoperators.dev`.
- **`deployment.yaml`**: Conditional `--leader-elect` arg; pod-level `securityContext` (`runAsNonRoot`); container-level `securityContext` (`allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`); preferred `podAntiAffinity` spread when `leaderElection` is enabled.
- **`leader-election-rbac.yaml`** (new): Namespaced `Role` + `RoleBinding` for `leases`, `configmaps`, `events` — rendered only when `manager.leaderElection=true`.
- **`poddisruptionbudget.yaml`** (new): `PodDisruptionBudget` with configurable `minAvailable` — rendered only when `manager.pdb.enabled=true`.
- **`values.yaml`**: New `manager.leaderElection` (default `false`), `manager.pdb.{enabled,minAvailable}`, and resource profile guidance comments.

## Test plan

- [x] `make build` — binary compiles with new flag
- [x] `make lint` — 0 issues
- [x] `make verify-manifests` — CRDs in sync
- [x] Helm render with defaults — no PDB, no leader-election RBAC, no `--leader-elect` arg
- [x] Helm render with `leaderElection=true`, `pdb.enabled=true`, `replicas=2` — all new resources rendered correctly
- [x] `make e2e-install` + `make e2e-test` — all scenarios pass with default config (single replica)
- [x] Helm upgrade with `replicas=2`, `leaderElection=true`, `pdb.enabled=true` — both pods Running, Lease object created, one pod elected leader, standby pod in `"Attempting to acquire leader lease..."` state, PDB and RBAC present in cluster
- [x] Restore to defaults + `make e2e-test` — all scenarios pass