### PR TITLE
refactor: modernize Go idioms (interface{}→any, range-N)

### DIFF
--- a/hack/ldap-testserver/main.go
+++ b/hack/ldap-testserver/main.go
@@ -66,7 +66,7 @@ func newServer(bindDN, bindPW, baseDN, group, user string) *server {
 
 func lower(s string) string {
 	b := make([]byte, len(s))
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		c := s[i]
 		if 'A' <= c && c <= 'Z' {
 			c += 'a' - 'A'

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -293,7 +293,7 @@ func startEnvtestWithRetry(env *envtest.Environment, attempts int, backoff time.
 	}
 
 	var lastErr error
-	for i := 0; i < attempts; i++ {
+	for range attempts {
 		cfg, err := env.Start()
 		if err == nil && cfg != nil {
 			return cfg, nil

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -15,9 +15,9 @@ var OperatorNamespace = "repo-guard-greenhouse-system"
 
 type dummyAssert struct{}
 
-func (t dummyAssert) Errorf(string, ...interface{}) {}
+func (t dummyAssert) Errorf(string, ...any) {}
 
-func elementsMatch(listA, listB interface{}) bool {
+func elementsMatch(listA, listB any) bool {
 	return assert.ElementsMatch(dummyAssert{}, listA, listB)
 }
 

--- a/internal/github/mock_server.go
+++ b/internal/github/mock_server.go
@@ -201,7 +201,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		writeJSON(w, map[string]interface{}{
+		writeJSON(w, map[string]any{
 			"login": org,
 			"id":    1,
 			"name":  org,
@@ -217,7 +217,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		writeJSON(w, map[string]interface{}{
+		writeJSON(w, map[string]any{
 			"id":   1,
 			"slug": "mock-app",
 			"name": "Mock GitHub App",
@@ -234,7 +234,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		writeJSONCreated(w, map[string]interface{}{
+		writeJSONCreated(w, map[string]any{
 			"token":      "mock-installation-token",
 			"expires_at": "2099-01-01T00:00:00Z",
 		})
@@ -278,7 +278,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 			}
 			stateMu.Unlock()
 		}
-		result := make([]map[string]interface{}, 0, len(users))
+		result := make([]map[string]any, 0, len(users))
 		for _, u := range users {
 			result = append(result, userToMap(u))
 		}
@@ -320,7 +320,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		writeJSON(w, []interface{}{})
+		writeJSON(w, []any{})
 	})
 
 	// GET /api/v3/orgs/{org}/invitations  (pending org invitations)
@@ -329,7 +329,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		writeJSON(w, []interface{}{})
+		writeJSON(w, []any{})
 	})
 
 	// /api/v3/orgs/{org}/memberships/{user} — PUT to change role, GET to get membership
@@ -362,7 +362,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 				orgMembers[strings.ToLower(username)] = u
 				stateMu.Unlock()
 			}
-			writeJSON(w, map[string]interface{}{"state": "active", "role": body.Role})
+			writeJSON(w, map[string]any{"state": "active", "role": body.Role})
 		case http.MethodGet:
 			stateMu.Lock()
 			_, isAdmin := orgAdmins[strings.ToLower(username)]
@@ -371,7 +371,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 			if isAdmin {
 				role = "admin"
 			}
-			writeJSON(w, map[string]interface{}{"state": "active", "role": role})
+			writeJSON(w, map[string]any{"state": "active", "role": role})
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
@@ -383,7 +383,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		writeJSON(w, map[string]interface{}{"state": "active", "role": "member"})
+		writeJSON(w, map[string]any{"state": "active", "role": "member"})
 	})
 
 	// ---- teams ----
@@ -397,7 +397,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 			snapshot := make([]MockTeam, len(teams))
 			copy(snapshot, teams)
 			stateMu.Unlock()
-			result := make([]map[string]interface{}, 0, len(snapshot))
+			result := make([]map[string]any, 0, len(snapshot))
 			for _, team := range snapshot {
 				result = append(result, teamToMap(team))
 			}
@@ -426,7 +426,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 			nextTeamID++
 			teams = append(teams, MockTeam{ID: id, Name: body.Name, Slug: teamSlugNew})
 			stateMu.Unlock()
-			writeJSONCreated(w, map[string]interface{}{"id": id, "name": body.Name, "slug": teamSlugNew})
+			writeJSONCreated(w, map[string]any{"id": id, "name": body.Name, "slug": teamSlugNew})
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
@@ -510,7 +510,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 				writeJSONError(w, `{"message":"Not Found"}`, http.StatusNotFound)
 				return
 			}
-			result := make([]map[string]interface{}, 0, len(members))
+			result := make([]map[string]any, 0, len(members))
 			for _, u := range members {
 				result = append(result, userToMap(u))
 			}
@@ -532,7 +532,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 				}
 				stateMu.Unlock()
 				if found {
-					writeJSON(w, map[string]interface{}{"state": "active", "role": "member"})
+					writeJSON(w, map[string]any{"state": "active", "role": "member"})
 				} else {
 					writeJSONError(w, `{"message":"Not Found"}`, http.StatusNotFound)
 				}
@@ -556,7 +556,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 					teamMembers[teamSlug] = append(teamMembers[teamSlug], u)
 				}
 				stateMu.Unlock()
-				writeJSON(w, map[string]interface{}{"state": "active", "role": "member"})
+				writeJSON(w, map[string]any{"state": "active", "role": "member"})
 			case http.MethodDelete:
 				stateMu.Lock()
 				var newList []MockUser
@@ -672,9 +672,9 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 			snapshot := make([]MockRepo, len(repos))
 			copy(snapshot, repos)
 			stateMu.Unlock()
-			result := make([]map[string]interface{}, 0, len(snapshot))
+			result := make([]map[string]any, 0, len(snapshot))
 			for _, repo := range snapshot {
-				result = append(result, map[string]interface{}{
+				result = append(result, map[string]any{
 					"name":       repo.Name,
 					"private":    repo.repoVisibility() != "public",
 					"visibility": repo.repoVisibility(),
@@ -724,7 +724,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 			}
 			repos = append(repos, MockRepo{Name: body.Name, Private: body.Private, Visibility: body.Visibility})
 			stateMu.Unlock()
-			writeJSONCreated(w, map[string]interface{}{
+			writeJSONCreated(w, map[string]any{
 				"name":       body.Name,
 				"private":    body.Private,
 				"visibility": body.Visibility,
@@ -762,7 +762,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 				writeJSONError(w, `{"message":"Not Found"}`, http.StatusNotFound)
 				return
 			}
-			writeJSON(w, map[string]interface{}{
+			writeJSON(w, map[string]any{
 				"name":       repoSnapshot.Name,
 				"private":    repoSnapshot.repoVisibility() != "public",
 				"visibility": repoSnapshot.repoVisibility(),
@@ -795,9 +795,9 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 			perms := make([]MockTeamWithPermission, len(teamRepoPerms[repoName]))
 			copy(perms, teamRepoPerms[repoName])
 			stateMu.Unlock()
-			result := make([]map[string]interface{}, 0, len(perms))
+			result := make([]map[string]any, 0, len(perms))
 			for _, tp := range perms {
-				result = append(result, map[string]interface{}{
+				result = append(result, map[string]any{
 					"id":         tp.ID,
 					"slug":       tp.Slug,
 					"name":       tp.Slug,
@@ -812,7 +812,7 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 				writeJSONError(w, `{"message":"Not Found"}`, http.StatusNotFound)
 				return
 			}
-			writeJSON(w, []interface{}{})
+			writeJSON(w, []any{})
 
 		// DELETE /api/v3/repos/{org}/{repo}/collaborators/{user}
 		case strings.HasPrefix(subPath, "collaborators/") && r.Method == http.MethodDelete:
@@ -884,8 +884,8 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 
 // userToMap converts a MockUser to a JSON-serialisable map with the field
 // shapes that go-github v85 expects.
-func userToMap(u MockUser) map[string]interface{} {
-	return map[string]interface{}{
+func userToMap(u MockUser) map[string]any {
+	return map[string]any{
 		"id":    u.ID,
 		"login": u.Login,
 		"type":  "User",
@@ -893,8 +893,8 @@ func userToMap(u MockUser) map[string]interface{} {
 }
 
 // teamToMap converts a MockTeam into the JSON map shape go-github expects.
-func teamToMap(team MockTeam) map[string]interface{} {
-	return map[string]interface{}{
+func teamToMap(team MockTeam) map[string]any {
+	return map[string]any{
 		"id":   team.ID,
 		"name": team.Name,
 		"slug": team.Slug,
@@ -912,7 +912,7 @@ func (r MockRepo) repoVisibility() string {
 	return "public"
 }
 
-func writeJSON(w http.ResponseWriter, v interface{}) {
+func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	// Encode errors are ignored: headers are already committed and we cannot
 	// send an error response at this point without corrupting the stream.
@@ -932,7 +932,7 @@ func writeJSONError(w http.ResponseWriter, body string, code int) {
 // Content-Type must be set before WriteHeader; this helper ensures correct ordering.
 // Encode errors are silently ignored because headers are already committed by the
 // time Encode writes the body and there is no way to signal the error to the client.
-func writeJSONCreated(w http.ResponseWriter, v interface{}) {
+func writeJSONCreated(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(v)

--- a/internal/github/mock_server_test.go
+++ b/internal/github/mock_server_test.go
@@ -147,7 +147,7 @@ func TestMockResponseShapes(t *testing.T) {
 }
 
 // mustDecode is a test helper that decodes JSON into v, failing the test on error.
-func mustDecode(t *testing.T, raw string, v interface{}) {
+func mustDecode(t *testing.T, raw string, v any) {
 	t.Helper()
 	if err := json.NewDecoder(strings.NewReader(raw)).Decode(v); err != nil {
 		t.Fatalf("json decode into %T: %v", v, err)

--- a/internal/github/repos_test.go
+++ b/internal/github/repos_test.go
@@ -41,14 +41,14 @@ func newTestRepositoryProvider(t *testing.T) (*DefaultRepositoryProvider, *http.
 func TestRepositoryProvider_List_VisibilityBuckets(t *testing.T) {
 	cases := []struct {
 		name         string
-		fixtures     []map[string]interface{}
+		fixtures     []map[string]any
 		wantPublic   []string
 		wantPrivate  []string
 		wantInternal []string
 	}{
 		{
 			name: "three-way split by visibility field",
-			fixtures: []map[string]interface{}{
+			fixtures: []map[string]any{
 				{"name": "pub-repo", "private": false, "visibility": "public"},
 				{"name": "priv-repo", "private": true, "visibility": "private"},
 				{"name": "int-repo", "private": true, "visibility": "internal"},
@@ -59,7 +59,7 @@ func TestRepositoryProvider_List_VisibilityBuckets(t *testing.T) {
 		},
 		{
 			name: "empty visibility falls back to private bool — private=true",
-			fixtures: []map[string]interface{}{
+			fixtures: []map[string]any{
 				{"name": "legacy-private", "private": true, "visibility": ""},
 			},
 			wantPublic:   []string{},
@@ -68,7 +68,7 @@ func TestRepositoryProvider_List_VisibilityBuckets(t *testing.T) {
 		},
 		{
 			name: "empty visibility falls back to private bool — private=false",
-			fixtures: []map[string]interface{}{
+			fixtures: []map[string]any{
 				{"name": "legacy-public", "private": false, "visibility": ""},
 			},
 			wantPublic:   []string{"legacy-public"},
@@ -77,7 +77,7 @@ func TestRepositoryProvider_List_VisibilityBuckets(t *testing.T) {
 		},
 		{
 			name: "unknown visibility skipped — not promoted to any bucket",
-			fixtures: []map[string]interface{}{
+			fixtures: []map[string]any{
 				{"name": "mystery-repo", "private": false, "visibility": "unknown-future-value"},
 			},
 			wantPublic:   []string{},
@@ -86,7 +86,7 @@ func TestRepositoryProvider_List_VisibilityBuckets(t *testing.T) {
 		},
 		{
 			name: "archived repo is excluded from all buckets",
-			fixtures: []map[string]interface{}{
+			fixtures: []map[string]any{
 				{"name": "pub-repo", "private": false, "visibility": "public"},
 				{"name": "archived-repo", "private": false, "visibility": "public", "archived": true},
 			},
@@ -96,7 +96,7 @@ func TestRepositoryProvider_List_VisibilityBuckets(t *testing.T) {
 		},
 		{
 			name: "disabled repo is excluded from all buckets",
-			fixtures: []map[string]interface{}{
+			fixtures: []map[string]any{
 				{"name": "priv-repo", "private": true, "visibility": "private"},
 				{"name": "disabled-repo", "private": true, "visibility": "private", "disabled": true},
 			},
@@ -106,7 +106,7 @@ func TestRepositoryProvider_List_VisibilityBuckets(t *testing.T) {
 		},
 		{
 			name:         "empty repo list",
-			fixtures:     []map[string]interface{}{},
+			fixtures:     []map[string]any{},
 			wantPublic:   []string{},
 			wantPrivate:  []string{},
 			wantInternal: []string{},

--- a/internal/github/teams_test.go
+++ b/internal/github/teams_test.go
@@ -38,12 +38,12 @@ func newTestTeamsProvider(t *testing.T) (*DefaultTeamsProvider, *http.ServeMux) 
 func TestTeamsProvider_List_EnterpriseFilter(t *testing.T) {
 	cases := []struct {
 		name      string
-		fixtures  []map[string]interface{}
+		fixtures  []map[string]any
 		wantTeams []string
 	}{
 		{
 			name: "enterprise team is excluded",
-			fixtures: []map[string]interface{}{
+			fixtures: []map[string]any{
 				{"id": 1, "name": "org-team", "slug": "org-team", "type": "organization"},
 				{"id": 2, "name": "enterprise-team", "slug": "enterprise-team", "type": "enterprise"},
 			},
@@ -51,14 +51,14 @@ func TestTeamsProvider_List_EnterpriseFilter(t *testing.T) {
 		},
 		{
 			name: "team without type field defaults to included",
-			fixtures: []map[string]interface{}{
+			fixtures: []map[string]any{
 				{"id": 1, "name": "regular-team", "slug": "regular-team"},
 			},
 			wantTeams: []string{"regular-team"},
 		},
 		{
 			name: "multiple enterprise teams are all excluded",
-			fixtures: []map[string]interface{}{
+			fixtures: []map[string]any{
 				{"id": 1, "name": "org-team-a", "slug": "org-team-a", "type": "organization"},
 				{"id": 2, "name": "ent-team-1", "slug": "ent-team-1", "type": "enterprise"},
 				{"id": 3, "name": "org-team-b", "slug": "org-team-b", "type": "organization"},
@@ -68,12 +68,12 @@ func TestTeamsProvider_List_EnterpriseFilter(t *testing.T) {
 		},
 		{
 			name:      "empty team list",
-			fixtures:  []map[string]interface{}{},
+			fixtures:  []map[string]any{},
 			wantTeams: []string{},
 		},
 		{
 			name: "all teams are enterprise — result is empty",
-			fixtures: []map[string]interface{}{
+			fixtures: []map[string]any{
 				{"id": 1, "name": "ent-only", "slug": "ent-only", "type": "enterprise"},
 			},
 			wantTeams: []string{},

--- a/internal/github/users.go
+++ b/internal/github/users.go
@@ -154,7 +154,7 @@ func (u *DefaultUsersProvider) HasVerifiedEmailDomainForGithubUID(ctx context.Co
 			Emails []githubv4.String `graphql:"organizationVerifiedDomainEmails(login: $org)"`
 		} `graphql:"user(login: $login)"`
 	}
-	vars := map[string]interface{}{
+	vars := map[string]any{
 		"login": githubv4.String(login),
 		"org":   githubv4.String(org),
 	}


### PR DESCRIPTION
## Summary

Modernize the codebase to use Go 1.26 idioms as tracked in issue #100.

- Replace all `interface{}` with `any` across production and test/support files (`utils.go`, `users.go`, `mock_server.go`, `mock_server_test.go`, `repos_test.go`, `teams_test.go`)
- Replace classic index loops (`for i := 0; i < n; i++`) with `for range n` / `for i := range n` where the loop variable is unused or only used for indexing (`suite_test.go`, `hack/ldap-testserver/main.go`)

Note: `omitzero` for `metav1.Time` fields was considered but dropped — it causes controller-gen to mark timestamp fields as `required` in the CRD OpenAPI schema, which is a backwards-incompatible change for existing clusters.

## Test plan

- [x] `make fmt` — no changes
- [x] `make vet` — passes clean
- [x] `make build` — compiles successfully
- [x] `make lint` — 0 issues
- [ ] `make controller-test` — integration tests pass