### PR TITLE
feat(github): reduce GitHub API consumption via GraphQL and ETag caching

### DIFF
--- a/dashboards/repoguard-status-ops-perses.json
+++ b/dashboards/repoguard-status-ops-perses.json
@@ -1047,7 +1047,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "100 * sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) / (sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) + sum(increase(repo_guard_github_etag_cache_misses_total{organization=~\"$org\"}[1h])))"
+                    "query": "100 * sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) / clamp_min(sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) + sum(increase(repo_guard_github_etag_cache_misses_total{organization=~\"$org\"}[1h])), 1)"
                   }
                 }
               }

--- a/dashboards/repoguard-status-ops-perses.json
+++ b/dashboards/repoguard-status-ops-perses.json
@@ -7,14 +7,14 @@
   },
   "spec": {
     "display": {
-      "name": "Repo Guard • Status & Operations"
+      "name": "Repo Guard \u2022 Status & Operations"
     },
     "panels": {
       "apiAuthErrors": {
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "📡 External API Errors (last 1h)",
+            "name": "\ud83d\udce1 External API Errors (last 1h)",
             "description": "Total failed external provider API calls (LDAP, HTTP member sources) in the last hour. Should stay at 0."
           },
           "plugin": {
@@ -23,8 +23,14 @@
               "calculation": "last-number",
               "thresholds": {
                 "steps": [
-                  { "color": "green", "value": 0 },
-                  { "color": "red", "value": 1 }
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
                 ]
               }
             }
@@ -48,7 +54,7 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "📡 External API Error Rates by HTTP Status",
+            "name": "\ud83d\udce1 External API Error Rates by HTTP Status",
             "description": "Rate of failed external provider API calls over time (LDAP, HTTP member sources), broken down by HTTP status code."
           },
           "plugin": {
@@ -79,7 +85,7 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "🚫 Organizations in Failed State",
+            "name": "\ud83d\udeab Organizations in Failed State",
             "description": "Number of GitHub organizations that failed to sync. Any value above 0 requires attention."
           },
           "plugin": {
@@ -88,8 +94,14 @@
               "calculation": "last-number",
               "thresholds": {
                 "steps": [
-                  { "color": "green", "value": 0 },
-                  { "color": "red", "value": 1 }
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
                 ]
               }
             }
@@ -113,7 +125,7 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "⏳ Organization Changes Waiting to Apply",
+            "name": "\u23f3 Organization Changes Waiting to Apply",
             "description": "Total pending operations across all organizations (team/repo/member changes queued but not yet applied to GitHub)."
           },
           "plugin": {
@@ -122,8 +134,14 @@
               "calculation": "last-number",
               "thresholds": {
                 "steps": [
-                  { "color": "green", "value": 0 },
-                  { "color": "orange", "value": 1 }
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
                 ]
               }
             }
@@ -147,7 +165,7 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "⏳ Org Membership Changes Waiting to Apply",
+            "name": "\u23f3 Org Membership Changes Waiting to Apply",
             "description": "Pending organization owner/member add or remove operations not yet applied to GitHub."
           },
           "plugin": {
@@ -156,8 +174,14 @@
               "calculation": "last-number",
               "thresholds": {
                 "steps": [
-                  { "color": "green", "value": 0 },
-                  { "color": "orange", "value": 1 }
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
                 ]
               }
             }
@@ -181,20 +205,41 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "🏢 Organizations Needing Attention (failed / rate-limited / pending)",
+            "name": "\ud83c\udfe2 Organizations Needing Attention (failed / rate-limited / pending)",
             "description": "Organizations currently in a non-healthy state. 'pending' means changes are queued, 'ratelimited' means GitHub API quota was hit, 'failed' means sync errors occurred."
           },
           "plugin": {
             "kind": "Table",
             "spec": {
               "columnSettings": [
-                { "name": "github", "header": "GitHub" },
-                { "name": "organization", "header": "Organization" },
-                { "name": "status", "header": "Status" },
-                { "name": "value", "hide": true },
-                { "name": "Value", "hide": true },
-                { "name": "timestamp", "hide": true },
-                { "name": "Time", "hide": true }
+                {
+                  "name": "github",
+                  "header": "GitHub"
+                },
+                {
+                  "name": "organization",
+                  "header": "Organization"
+                },
+                {
+                  "name": "status",
+                  "header": "Status"
+                },
+                {
+                  "name": "value",
+                  "hide": true
+                },
+                {
+                  "name": "Value",
+                  "hide": true
+                },
+                {
+                  "name": "timestamp",
+                  "hide": true
+                },
+                {
+                  "name": "Time",
+                  "hide": true
+                }
               ]
             }
           },
@@ -217,7 +262,7 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "👤 Member Add / Remove Activity",
+            "name": "\ud83d\udc64 Member Add / Remove Activity",
             "description": "Rate of team member additions and removals applied to GitHub over time."
           },
           "plugin": {
@@ -248,7 +293,7 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "🚦 Organizations Currently Rate-Limited by GitHub",
+            "name": "\ud83d\udea6 Organizations Currently Rate-Limited by GitHub",
             "description": "Number of organizations where the controller is blocked by GitHub API rate limits right now."
           },
           "plugin": {
@@ -257,8 +302,14 @@
               "calculation": "last-number",
               "thresholds": {
                 "steps": [
-                  { "color": "green", "value": 0 },
-                  { "color": "orange", "value": 1 }
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
                 ]
               }
             }
@@ -282,14 +333,20 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "⏱️ How Long Does One Sync Cycle Take? (p95)",
+            "name": "\u23f1\ufe0f How Long Does One Sync Cycle Take? (p95)",
             "description": "95th percentile time for the controller to complete one reconcile loop per controller type. High values mean the controller is slow to react to changes."
           },
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
-              "legend": { "position": "bottom" },
-              "yAxis": { "format": { "unit": "seconds" } }
+              "legend": {
+                "position": "bottom"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "seconds"
+                }
+              }
             }
           },
           "queries": [
@@ -312,7 +369,7 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "🚫 Teams in Failed State",
+            "name": "\ud83d\udeab Teams in Failed State",
             "description": "Number of GitHub teams that failed to sync. Any value above 0 requires attention."
           },
           "plugin": {
@@ -321,8 +378,14 @@
               "calculation": "last-number",
               "thresholds": {
                 "steps": [
-                  { "color": "green", "value": 0 },
-                  { "color": "red", "value": 1 }
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
                 ]
               }
             }
@@ -346,7 +409,7 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "⏳ Team Member Changes Waiting to Apply",
+            "name": "\u23f3 Team Member Changes Waiting to Apply",
             "description": "Pending team membership operations (add/remove members) not yet applied to GitHub."
           },
           "plugin": {
@@ -355,8 +418,14 @@
               "calculation": "last-number",
               "thresholds": {
                 "steps": [
-                  { "color": "green", "value": 0 },
-                  { "color": "orange", "value": 1 }
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  }
                 ]
               }
             }
@@ -380,7 +449,7 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "🏢 GitHub Changes Applied Over Time (Teams, Repos, Members)",
+            "name": "\ud83c\udfe2 GitHub Changes Applied Over Time (Teams, Repos, Members)",
             "description": "Rate of completed operations: adding/removing teams, repos, and org members. A flat line means no changes are being applied."
           },
           "plugin": {
@@ -411,20 +480,41 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "👥 Teams Needing Attention (failed / rate-limited / pending)",
+            "name": "\ud83d\udc65 Teams Needing Attention (failed / rate-limited / pending)",
             "description": "Teams currently in a non-healthy state. 'pending' means member changes are queued, 'ratelimited' means GitHub API quota was hit, 'failed' means sync errors occurred."
           },
           "plugin": {
             "kind": "Table",
             "spec": {
               "columnSettings": [
-                { "name": "organization", "header": "Organization" },
-                { "name": "status", "header": "Status" },
-                { "name": "team", "header": "Team" },
-                { "name": "value", "hide": true },
-                { "name": "Value", "hide": true },
-                { "name": "timestamp", "hide": true },
-                { "name": "Time", "hide": true }
+                {
+                  "name": "organization",
+                  "header": "Organization"
+                },
+                {
+                  "name": "status",
+                  "header": "Status"
+                },
+                {
+                  "name": "team",
+                  "header": "Team"
+                },
+                {
+                  "name": "value",
+                  "hide": true
+                },
+                {
+                  "name": "Value",
+                  "hide": true
+                },
+                {
+                  "name": "timestamp",
+                  "hide": true
+                },
+                {
+                  "name": "Time",
+                  "hide": true
+                }
               ]
             }
           },
@@ -447,20 +537,41 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "🏢 All Organizations — Last Known Status",
+            "name": "\ud83c\udfe2 All Organizations \u2014 Last Known Status",
             "description": "Most recent sync status for every managed organization over the selected time range."
           },
           "plugin": {
             "kind": "Table",
             "spec": {
               "columnSettings": [
-                { "name": "github", "header": "GitHub" },
-                { "name": "organization", "header": "Organization" },
-                { "name": "status", "header": "Status" },
-                { "name": "value", "hide": true },
-                { "name": "Value", "hide": true },
-                { "name": "timestamp", "hide": true },
-                { "name": "Time", "hide": true }
+                {
+                  "name": "github",
+                  "header": "GitHub"
+                },
+                {
+                  "name": "organization",
+                  "header": "Organization"
+                },
+                {
+                  "name": "status",
+                  "header": "Status"
+                },
+                {
+                  "name": "value",
+                  "hide": true
+                },
+                {
+                  "name": "Value",
+                  "hide": true
+                },
+                {
+                  "name": "timestamp",
+                  "hide": true
+                },
+                {
+                  "name": "Time",
+                  "hide": true
+                }
               ]
             }
           },
@@ -483,20 +594,41 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "👥 All Teams — Last Known Status",
+            "name": "\ud83d\udc65 All Teams \u2014 Last Known Status",
             "description": "Most recent sync status for every managed team over the selected time range."
           },
           "plugin": {
             "kind": "Table",
             "spec": {
               "columnSettings": [
-                { "name": "organization", "header": "Organization" },
-                { "name": "status", "header": "Status" },
-                { "name": "team", "header": "Team" },
-                { "name": "value", "hide": true },
-                { "name": "Value", "hide": true },
-                { "name": "timestamp", "hide": true },
-                { "name": "Time", "hide": true }
+                {
+                  "name": "organization",
+                  "header": "Organization"
+                },
+                {
+                  "name": "status",
+                  "header": "Status"
+                },
+                {
+                  "name": "team",
+                  "header": "Team"
+                },
+                {
+                  "name": "value",
+                  "hide": true
+                },
+                {
+                  "name": "Value",
+                  "hide": true
+                },
+                {
+                  "name": "timestamp",
+                  "hide": true
+                },
+                {
+                  "name": "Time",
+                  "hide": true
+                }
               ]
             }
           },
@@ -518,16 +650,34 @@
       "managedTeams": {
         "kind": "Panel",
         "spec": {
-          "display": { "name": "🏢 Teams Managed per Organization", "description": "Number of GitHub teams currently tracked per organization. Derived from active GithubTeam resources after filtering." },
+          "display": {
+            "name": "\ud83c\udfe2 Teams Managed per Organization",
+            "description": "Number of GitHub teams currently tracked per organization. Derived from active GithubTeam resources after filtering."
+          },
           "plugin": {
             "kind": "Table",
             "spec": {
               "columnSettings": [
-                { "name": "github", "header": "GitHub" },
-                { "name": "organization", "header": "Organization" },
-                { "name": "value", "header": "Teams" },
-                { "name": "timestamp", "hide": true },
-                { "name": "Time", "hide": true }
+                {
+                  "name": "github",
+                  "header": "GitHub"
+                },
+                {
+                  "name": "organization",
+                  "header": "Organization"
+                },
+                {
+                  "name": "value",
+                  "header": "Teams"
+                },
+                {
+                  "name": "timestamp",
+                  "hide": true
+                },
+                {
+                  "name": "Time",
+                  "hide": true
+                }
               ]
             }
           },
@@ -537,7 +687,9 @@
               "spec": {
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
-                  "spec": { "query": "sum by (github, organization) (repo_guard_githuborganization_managed_teams_total{github=~\"$github\", organization=~\"$org\"})" }
+                  "spec": {
+                    "query": "sum by (github, organization) (repo_guard_githuborganization_managed_teams_total{github=~\"$github\", organization=~\"$org\"})"
+                  }
                 }
               }
             }
@@ -547,17 +699,38 @@
       "managedReposByVisibility": {
         "kind": "Panel",
         "spec": {
-          "display": { "name": "📁 Repos Managed per Organization (by Visibility)", "description": "Number of GitHub repositories actively managed per organization, broken down by visibility (public, private, internal)." },
+          "display": {
+            "name": "\ud83d\udcc1 Repos Managed per Organization (by Visibility)",
+            "description": "Number of GitHub repositories actively managed per organization, broken down by visibility (public, private, internal)."
+          },
           "plugin": {
             "kind": "Table",
             "spec": {
               "columnSettings": [
-                { "name": "github", "header": "GitHub" },
-                { "name": "organization", "header": "Organization" },
-                { "name": "visibility", "header": "Visibility" },
-                { "name": "value", "header": "Repos" },
-                { "name": "timestamp", "hide": true },
-                { "name": "Time", "hide": true }
+                {
+                  "name": "github",
+                  "header": "GitHub"
+                },
+                {
+                  "name": "organization",
+                  "header": "Organization"
+                },
+                {
+                  "name": "visibility",
+                  "header": "Visibility"
+                },
+                {
+                  "name": "value",
+                  "header": "Repos"
+                },
+                {
+                  "name": "timestamp",
+                  "hide": true
+                },
+                {
+                  "name": "Time",
+                  "hide": true
+                }
               ]
             }
           },
@@ -567,7 +740,9 @@
               "spec": {
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
-                  "spec": { "query": "sum by (github, organization, visibility) (repo_guard_githuborganization_managed_repos_total{github=~\"$github\", organization=~\"$org\"})" }
+                  "spec": {
+                    "query": "sum by (github, organization, visibility) (repo_guard_githuborganization_managed_repos_total{github=~\"$github\", organization=~\"$org\"})"
+                  }
                 }
               }
             }
@@ -577,15 +752,30 @@
       "managedMembers": {
         "kind": "Panel",
         "spec": {
-          "display": { "name": "👥 Team Memberships per Organization (sum across teams)", "description": "Total managed team membership slots per organization, summed across all teams. Note: a user in multiple teams is counted once per team." },
+          "display": {
+            "name": "\ud83d\udc65 Team Memberships per Organization (sum across teams)",
+            "description": "Total managed team membership slots per organization, summed across all teams. Note: a user in multiple teams is counted once per team."
+          },
           "plugin": {
             "kind": "Table",
             "spec": {
               "columnSettings": [
-                { "name": "organization", "header": "Organization" },
-                { "name": "value", "header": "Members" },
-                { "name": "timestamp", "hide": true },
-                { "name": "Time", "hide": true }
+                {
+                  "name": "organization",
+                  "header": "Organization"
+                },
+                {
+                  "name": "value",
+                  "header": "Members"
+                },
+                {
+                  "name": "timestamp",
+                  "hide": true
+                },
+                {
+                  "name": "Time",
+                  "hide": true
+                }
               ]
             }
           },
@@ -595,7 +785,9 @@
               "spec": {
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
-                  "spec": { "query": "sum by (organization) (repo_guard_githubteam_managed_members_total{organization=~\"$org\"})" }
+                  "spec": {
+                    "query": "sum by (organization) (repo_guard_githubteam_managed_members_total{organization=~\"$org\"})"
+                  }
                 }
               }
             }
@@ -606,12 +798,16 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "⏳ Total Pending Operations Over Time",
+            "name": "\u23f3 Total Pending Operations Over Time",
             "description": "How many changes are queued and waiting to be applied to GitHub, per organization over time. A sustained high value means the controller is falling behind."
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": { "legend": { "position": "bottom" } }
+            "spec": {
+              "legend": {
+                "position": "bottom"
+              }
+            }
           },
           "queries": [
             {
@@ -619,7 +815,10 @@
               "spec": {
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
-                  "spec": { "query": "repo_guard_githuborganization_pending_operations_total{github=~\"$github\", organization=~\"$org\"}", "seriesNameFormat": "{{organization}}" }
+                  "spec": {
+                    "query": "repo_guard_githuborganization_pending_operations_total{github=~\"$github\", organization=~\"$org\"}",
+                    "seriesNameFormat": "{{organization}}"
+                  }
                 }
               }
             }
@@ -630,12 +829,16 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "🚫 Sync Failure Rate per Organization",
+            "name": "\ud83d\udeab Sync Failure Rate per Organization",
             "description": "How often each organization's sync is failing, broken down by scope (overall, repos, owners). Any sustained non-zero value means repeated errors."
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": { "legend": { "position": "bottom" } }
+            "spec": {
+              "legend": {
+                "position": "bottom"
+              }
+            }
           },
           "queries": [
             {
@@ -643,7 +846,10 @@
               "spec": {
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
-                  "spec": { "query": "rate(repo_guard_githuborganization_sync_failures_total{github=~\"$github\", organization=~\"$org\"}[5m])", "seriesNameFormat": "{{organization}} / {{scope}}" }
+                  "spec": {
+                    "query": "rate(repo_guard_githuborganization_sync_failures_total{github=~\"$github\", organization=~\"$org\"}[5m])",
+                    "seriesNameFormat": "{{organization}} / {{scope}}"
+                  }
                 }
               }
             }
@@ -654,12 +860,16 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "🚦 GitHub Rate-Limit Hits Over Time",
+            "name": "\ud83d\udea6 GitHub Rate-Limit Hits Over Time",
             "description": "How many times the controller was blocked by GitHub API rate limits, per controller type. Spikes indicate heavy API usage periods."
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": { "legend": { "position": "bottom" } }
+            "spec": {
+              "legend": {
+                "position": "bottom"
+              }
+            }
           },
           "queries": [
             {
@@ -667,7 +877,10 @@
               "spec": {
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
-                  "spec": { "query": "increase(repo_guard_github_ratelimit_hits_total[1h])", "seriesNameFormat": "{{controller}} / {{type}}" }
+                  "spec": {
+                    "query": "increase(repo_guard_github_ratelimit_hits_total[1h])",
+                    "seriesNameFormat": "{{controller}} / {{type}}"
+                  }
                 }
               }
             }
@@ -678,19 +891,30 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "⏱️ How Long Is the Controller Waiting After a Rate-Limit? (p95)",
+            "name": "\u23f1\ufe0f How Long Is the Controller Waiting After a Rate-Limit? (p95)",
             "description": "95th percentile backoff duration after hitting GitHub API rate limits. Orange = >5 min wait, Red = >30 min wait."
           },
           "plugin": {
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
-              "format": { "unit": "seconds" },
+              "format": {
+                "unit": "seconds"
+              },
               "thresholds": {
                 "steps": [
-                  { "color": "green", "value": 0 },
-                  { "color": "orange", "value": 300 },
-                  { "color": "red", "value": 1800 }
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "orange",
+                    "value": 300
+                  },
+                  {
+                    "color": "red",
+                    "value": 1800
+                  }
                 ]
               }
             }
@@ -701,7 +925,130 @@
               "spec": {
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
-                  "spec": { "query": "histogram_quantile(0.95, sum by (le) (rate(repo_guard_github_ratelimit_backoff_seconds_bucket[1h])))" }
+                  "spec": {
+                    "query": "histogram_quantile(0.95, sum by (le) (rate(repo_guard_github_ratelimit_backoff_seconds_bucket[1h])))"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "graphqlCalls": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "\u26a1 GraphQL Calls per Hour",
+            "description": "Number of GitHub GraphQL API calls per hour by organization and result (success/error). High error counts indicate API or auth issues."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "increase(repo_guard_github_graphql_calls_total{organization=~\"$org\"}[1h])",
+                    "seriesNameFormat": "{{organization}} / {{result}}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "etagCacheHitsMisses": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "\ud83d\udce6 ETag Cache \u2014 Hits vs Misses per Hour",
+            "description": "HTTP 304 cache hits (saved API calls) versus 200 cache misses (full fetches) per endpoint. More hits = fewer GitHub API calls consumed."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])",
+                    "seriesNameFormat": "hit \u00b7 {{organization}} / {{endpoint}}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "increase(repo_guard_github_etag_cache_misses_total{organization=~\"$org\"}[1h])",
+                    "seriesNameFormat": "miss \u00b7 {{organization}} / {{endpoint}}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "etagCacheHitRatio": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "\ud83d\udcc8 ETag Cache Hit Ratio",
+            "description": "Fraction of REST list calls answered from cache (HTTP 304) over the last hour. Green \u2265 80%, Orange \u2265 50%, Red < 50%."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": 0
+                  },
+                  {
+                    "color": "orange",
+                    "value": 50
+                  },
+                  {
+                    "color": "green",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "100 * sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) / (sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) + sum(increase(repo_guard_github_etag_cache_misses_total{organization=~\"$org\"}[1h])))"
+                  }
                 }
               }
             }
@@ -725,105 +1072,135 @@
               "y": 0,
               "width": 5,
               "height": 4,
-              "content": { "$ref": "#/spec/panels/orgFailures" }
+              "content": {
+                "$ref": "#/spec/panels/orgFailures"
+              }
             },
             {
               "x": 5,
               "y": 0,
               "width": 5,
               "height": 4,
-              "content": { "$ref": "#/spec/panels/orgPending" }
+              "content": {
+                "$ref": "#/spec/panels/orgPending"
+              }
             },
             {
               "x": 10,
               "y": 0,
               "width": 5,
               "height": 4,
-              "content": { "$ref": "#/spec/panels/orgMemberPending" }
+              "content": {
+                "$ref": "#/spec/panels/orgMemberPending"
+              }
             },
             {
               "x": 15,
               "y": 0,
               "width": 5,
               "height": 4,
-              "content": { "$ref": "#/spec/panels/teamFailures" }
+              "content": {
+                "$ref": "#/spec/panels/teamFailures"
+              }
             },
             {
               "x": 20,
               "y": 0,
               "width": 4,
               "height": 4,
-              "content": { "$ref": "#/spec/panels/teamPending" }
+              "content": {
+                "$ref": "#/spec/panels/teamPending"
+              }
             },
             {
               "x": 0,
               "y": 4,
               "width": 12,
               "height": 10,
-              "content": { "$ref": "#/spec/panels/orgsAttention" }
+              "content": {
+                "$ref": "#/spec/panels/orgsAttention"
+              }
             },
             {
               "x": 12,
               "y": 4,
               "width": 12,
               "height": 10,
-              "content": { "$ref": "#/spec/panels/teamsAttention" }
+              "content": {
+                "$ref": "#/spec/panels/teamsAttention"
+              }
             },
             {
               "x": 0,
               "y": 14,
               "width": 12,
               "height": 8,
-              "content": { "$ref": "#/spec/panels/peopleOps" }
+              "content": {
+                "$ref": "#/spec/panels/peopleOps"
+              }
             },
             {
               "x": 12,
               "y": 14,
               "width": 12,
               "height": 8,
-              "content": { "$ref": "#/spec/panels/teamRepoOps" }
+              "content": {
+                "$ref": "#/spec/panels/teamRepoOps"
+              }
             },
             {
               "x": 0,
               "y": 22,
               "width": 6,
               "height": 4,
-              "content": { "$ref": "#/spec/panels/apiAuthErrors" }
+              "content": {
+                "$ref": "#/spec/panels/apiAuthErrors"
+              }
             },
             {
               "x": 6,
               "y": 22,
               "width": 6,
               "height": 4,
-              "content": { "$ref": "#/spec/panels/rateLimitStatus" }
+              "content": {
+                "$ref": "#/spec/panels/rateLimitStatus"
+              }
             },
             {
               "x": 12,
               "y": 22,
               "width": 12,
               "height": 8,
-              "content": { "$ref": "#/spec/panels/apiErrorRates" }
+              "content": {
+                "$ref": "#/spec/panels/apiErrorRates"
+              }
             },
             {
               "x": 0,
               "y": 26,
               "width": 12,
               "height": 8,
-              "content": { "$ref": "#/spec/panels/reconcileDuration" }
+              "content": {
+                "$ref": "#/spec/panels/reconcileDuration"
+              }
             },
             {
               "x": 0,
               "y": 34,
               "width": 12,
               "height": 8,
-              "content": { "$ref": "#/spec/panels/orgsStatus" }
+              "content": {
+                "$ref": "#/spec/panels/orgsStatus"
+              }
             },
             {
               "x": 12,
               "y": 34,
               "width": 12,
               "height": 8,
-              "content": { "$ref": "#/spec/panels/teamsStatus" }
+              "content": {
+                "$ref": "#/spec/panels/teamsStatus"
+              }
             }
           ]
         }
@@ -832,7 +1209,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "📦 Inventory — Managed Resources",
+            "title": "\ud83d\udce6 Inventory \u2014 Managed Resources",
             "collapse": {
               "open": false
             }
@@ -843,49 +1220,103 @@
               "y": 0,
               "width": 8,
               "height": 8,
-              "content": { "$ref": "#/spec/panels/managedTeams" }
+              "content": {
+                "$ref": "#/spec/panels/managedTeams"
+              }
             },
             {
               "x": 8,
               "y": 0,
               "width": 8,
               "height": 8,
-              "content": { "$ref": "#/spec/panels/managedReposByVisibility" }
+              "content": {
+                "$ref": "#/spec/panels/managedReposByVisibility"
+              }
             },
             {
               "x": 16,
               "y": 0,
               "width": 8,
               "height": 8,
-              "content": { "$ref": "#/spec/panels/managedMembers" }
+              "content": {
+                "$ref": "#/spec/panels/managedMembers"
+              }
             },
             {
               "x": 0,
               "y": 8,
               "width": 12,
               "height": 8,
-              "content": { "$ref": "#/spec/panels/pendingOperationsTotal" }
+              "content": {
+                "$ref": "#/spec/panels/pendingOperationsTotal"
+              }
             },
             {
               "x": 12,
               "y": 8,
               "width": 12,
               "height": 8,
-              "content": { "$ref": "#/spec/panels/syncFailuresRate" }
+              "content": {
+                "$ref": "#/spec/panels/syncFailuresRate"
+              }
             },
             {
               "x": 0,
               "y": 16,
               "width": 12,
               "height": 8,
-              "content": { "$ref": "#/spec/panels/rateLimitHits" }
+              "content": {
+                "$ref": "#/spec/panels/rateLimitHits"
+              }
             },
             {
               "x": 12,
               "y": 16,
               "width": 12,
               "height": 8,
-              "content": { "$ref": "#/spec/panels/rateLimitBackoffP95" }
+              "content": {
+                "$ref": "#/spec/panels/rateLimitBackoffP95"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "\ud83d\ude80 GitHub API Efficiency",
+            "collapse": {
+              "open": true
+            }
+          },
+          "items": [
+            {
+              "content": {
+                "$ref": "#/spec/panels/graphqlCalls"
+              },
+              "x": 0,
+              "y": 0,
+              "width": 8,
+              "height": 8
+            },
+            {
+              "content": {
+                "$ref": "#/spec/panels/etagCacheHitsMisses"
+              },
+              "x": 8,
+              "y": 0,
+              "width": 8,
+              "height": 8
+            },
+            {
+              "content": {
+                "$ref": "#/spec/panels/etagCacheHitRatio"
+              },
+              "x": 16,
+              "y": 0,
+              "width": 8,
+              "height": 8
             }
           ]
         }

--- a/dashboards/repoguard-status-ops-perses.json
+++ b/dashboards/repoguard-status-ops-perses.json
@@ -956,7 +956,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "increase(repo_guard_github_graphql_calls_total{organization=~\"$org\"}[1h])",
+                    "query": "increase(repo_guard_github_graphql_calls_total{github=~\"$github\",organization=~\"$org\"}[1h])",
                     "seriesNameFormat": "{{organization}} / {{result}}"
                   }
                 }
@@ -987,7 +987,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])",
+                    "query": "increase(repo_guard_github_etag_cache_hits_total{github=~\"$github\",organization=~\"$org\"}[1h])",
                     "seriesNameFormat": "hit \u00b7 {{organization}} / {{endpoint}}"
                   }
                 }
@@ -999,7 +999,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "increase(repo_guard_github_etag_cache_misses_total{organization=~\"$org\"}[1h])",
+                    "query": "increase(repo_guard_github_etag_cache_misses_total{github=~\"$github\",organization=~\"$org\"}[1h])",
                     "seriesNameFormat": "miss \u00b7 {{organization}} / {{endpoint}}"
                   }
                 }
@@ -1047,7 +1047,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "100 * sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) / clamp_min(sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) + sum(increase(repo_guard_github_etag_cache_misses_total{organization=~\"$org\"}[1h])), 1)"
+                    "query": "100 * sum(increase(repo_guard_github_etag_cache_hits_total{github=~\"$github\",organization=~\"$org\"}[1h])) / clamp_min(sum(increase(repo_guard_github_etag_cache_hits_total{github=~\"$github\",organization=~\"$org\"}[1h])) + sum(increase(repo_guard_github_etag_cache_misses_total{github=~\"$github\",organization=~\"$org\"}[1h])), 1)"
                   }
                 }
               }

--- a/dashboards/repoguard-status-ops-plutono.json
+++ b/dashboards/repoguard-status-ops-plutono.json
@@ -17,500 +17,1469 @@
   "panels": [
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 100,
       "panels": [],
-      "title": "🟢 Live Information",
+      "title": "\ud83d\udfe2 Live Information",
       "type": "row"
     },
     {
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            { "options": { "0": { "color": "green", "index": 0, "text": "✅ OK" } }, "type": "value" }
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "\u2705 OK"
+                }
+              },
+              "type": "value"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           }
         }
       },
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
       "id": 1,
       "options": {
         "colorMode": "background",
         "graphMode": "area",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "textMode": "value_and_name"
       },
-      "title": "🚫 Org Failures",
+      "title": "\ud83d\udeab Org Failures",
       "type": "stat",
       "targets": [
-        { "expr": "sum(repo_guard_githuborganization_status{status=\"failed\", github=~\"$github\", organization=~\"$org\"} == 1) or vector(0)", "legendFormat": "Failed Organizations", "refId": "A" }
+        {
+          "expr": "sum(repo_guard_githuborganization_status{status=\"failed\", github=~\"$github\", organization=~\"$org\"} == 1) or vector(0)",
+          "legendFormat": "Failed Organizations",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            { "options": { "0": { "color": "green", "index": 0, "text": "✅ OK" } }, "type": "value" }
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "\u2705 OK"
+                }
+              },
+              "type": "value"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "orange", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
             ]
           }
         }
       },
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
       "id": 3,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "center",
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "textMode": "value_and_name"
       },
-      "title": "⏳ Org Pending Ops",
+      "title": "\u23f3 Org Pending Ops",
       "type": "stat",
       "targets": [
-        { "expr": "sum(repo_guard_githuborganization_operations{state=\"pending\", github=~\"$github\", organization=~\"$org\"}) or vector(0)", "refId": "A" }
+        {
+          "expr": "sum(repo_guard_githuborganization_operations{state=\"pending\", github=~\"$github\", organization=~\"$org\"}) or vector(0)",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            { "options": { "0": { "color": "green", "index": 0, "text": "✅ OK" } }, "type": "value" }
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "\u2705 OK"
+                }
+              },
+              "type": "value"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           }
         }
       },
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
       "id": 2,
-      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value_and_name" },
-      "title": "🚫 Team Failures",
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name"
+      },
+      "title": "\ud83d\udeab Team Failures",
       "type": "stat",
       "targets": [
-        { "expr": "sum(repo_guard_githubteam_status{status=\"failed\", organization=~\"$org\", team=~\"$team\"} == 1) or vector(0)", "refId": "A" }
+        {
+          "expr": "sum(repo_guard_githubteam_status{status=\"failed\", organization=~\"$org\", team=~\"$team\"} == 1) or vector(0)",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            { "options": { "0": { "color": "green", "index": 0, "text": "✅ OK" } }, "type": "value" }
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "\u2705 OK"
+                }
+              },
+              "type": "value"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "orange", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
             ]
           }
         }
       },
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
       "id": 30,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value_and_name" },
-      "title": "⏳ Team Pending Ops",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name"
+      },
+      "title": "\u23f3 Team Pending Ops",
       "type": "stat",
       "targets": [
-        { "expr": "sum(repo_guard_githubteam_operations{state=\"pending\", organization=~\"$org\", team=~\"$team\"}) or vector(0)", "refId": "A" }
+        {
+          "expr": "sum(repo_guard_githubteam_operations{state=\"pending\", organization=~\"$org\", team=~\"$team\"}) or vector(0)",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            { "options": { "0": { "color": "green", "index": 0, "text": "✅ OK" } }, "type": "value" }
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "\u2705 OK"
+                }
+              },
+              "type": "value"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "orange", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
             ]
           }
         }
       },
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 5 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 5
+      },
       "id": 31,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value_and_name" },
-      "title": "⏳ Org Member Pending Ops",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name"
+      },
+      "title": "\u23f3 Org Member Pending Ops",
       "type": "stat",
       "targets": [
-        { "expr": "sum(repo_guard_githuborganization_operations{scope=\"orgmembers\", state=\"pending\", github=~\"$github\", organization=~\"$org\"}) or vector(0)", "refId": "A" }
+        {
+          "expr": "sum(repo_guard_githuborganization_operations{scope=\"orgmembers\", state=\"pending\", github=~\"$github\", organization=~\"$org\"}) or vector(0)",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
-            { "options": { "0": { "color": "green", "index": 0, "text": "✅ OK" } }, "type": "value" }
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "\u2705 OK"
+                }
+              },
+              "type": "value"
+            }
           ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "orange", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
             ]
           }
         }
       },
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 5 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 5
+      },
       "id": 32,
-      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value_and_name" },
-      "title": "⏳ Repo Direct Collab Pending Ops",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name"
+      },
+      "title": "\u23f3 Repo Direct Collab Pending Ops",
       "type": "stat",
       "targets": [
-        { "expr": "sum(repo_guard_githuborganization_operations{scope=\"repocollaborators\", state=\"pending\", github=~\"$github\", organization=~\"$org\"}) or vector(0)", "refId": "A" }
+        {
+          "expr": "sum(repo_guard_githuborganization_operations{scope=\"repocollaborators\", state=\"pending\", github=~\"$github\", organization=~\"$org\"}) or vector(0)",
+          "refId": "A"
+        }
       ]
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
       "id": 200,
       "panels": [],
-      "title": "⚠️ Current Status",
+      "title": "\u26a0\ufe0f Current Status",
       "type": "row"
     },
     {
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "custom": { "align": "auto", "displayMode": "color-background-status" },
+          "custom": {
+            "align": "auto",
+            "displayMode": "color-background-status"
+          },
           "mappings": [
-            { "options": { "failed": { "color": "red", "index": 0 }, "ratelimited": { "color": "yellow", "index": 1 }, "pending": { "color": "orange", "index": 2 } }, "type": "value" }
+            {
+              "options": {
+                "failed": {
+                  "color": "red",
+                  "index": 0
+                },
+                "ratelimited": {
+                  "color": "yellow",
+                  "index": 1
+                },
+                "pending": {
+                  "color": "orange",
+                  "index": 2
+                }
+              },
+              "type": "value"
+            }
           ]
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "organization" }, "properties": [ { "id": "custom.width", "value": 200 } ] },
-          { "matcher": { "id": "byName", "options": "status" }, "properties": [ { "id": "custom.width", "value": 150 } ] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "organization"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 200
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
       "id": 10,
-      "options": { "footer": { "show": false }, "showHeader": true },
-      "title": "🏢 Organizations • Current Status",
+      "options": {
+        "footer": {
+          "show": false
+        },
+        "showHeader": true
+      },
+      "title": "\ud83c\udfe2 Organizations \u2022 Current Status",
       "type": "table",
       "targets": [
-        { "expr": "sum by (github, organization, status) (repo_guard_githuborganization_status{github=~\"$github\", organization=~\"$org\", status=~\"failed|ratelimited|pending\"} == 1)", "format": "table", "instant": true, "refId": "A" }
+        {
+          "expr": "sum by (github, organization, status) (repo_guard_githuborganization_status{github=~\"$github\", organization=~\"$org\", status=~\"failed|ratelimited|pending\"} == 1)",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
       "id": 11,
-      "options": { "footer": { "show": false }, "showHeader": true },
-      "title": "👥 Teams • Current Status",
+      "options": {
+        "footer": {
+          "show": false
+        },
+        "showHeader": true
+      },
+      "title": "\ud83d\udc65 Teams \u2022 Current Status",
       "type": "table",
       "targets": [
-        { "expr": "sum by (organization, team, status) (repo_guard_githubteam_status{status=~\"failed|ratelimited|pending\", organization=~\"$org\", team=~\"$team\"} == 1)", "format": "table", "instant": true, "refId": "A" }
+        {
+          "expr": "sum by (organization, team, status) (repo_guard_githubteam_status{status=~\"failed|ratelimited|pending\", organization=~\"$org\", team=~\"$team\"} == 1)",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
       ],
       "fieldConfig": {
         "defaults": {
-          "custom": { "displayMode": "color-background-status" },
+          "custom": {
+            "displayMode": "color-background-status"
+          },
           "mappings": [
-            { "options": { "failed": { "color": "red" }, "ratelimited": { "color": "yellow" }, "pending": { "color": "orange" } }, "type": "value" }
+            {
+              "options": {
+                "failed": {
+                  "color": "red"
+                },
+                "ratelimited": {
+                  "color": "yellow"
+                },
+                "pending": {
+                  "color": "orange"
+                }
+              },
+              "type": "value"
+            }
           ]
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "organization" }, "properties": [ { "id": "custom.width", "value": 150 } ] },
-          { "matcher": { "id": "byName", "options": "team" }, "properties": [ { "id": "custom.width", "value": 250 } ] },
-          { "matcher": { "id": "byName", "options": "status" }, "properties": [ { "id": "custom.width", "value": 150 } ] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "organization"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "team"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
         ]
       }
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
       "id": 300,
       "panels": [],
-      "title": "📈 Operation Summary (Last 24h)",
+      "title": "\ud83d\udcc8 Operation Summary (Last 24h)",
       "type": "row"
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
       "id": 34,
-      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "title": "👤 People Operations (Line Chart)",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "title": "\ud83d\udc64 People Operations (Line Chart)",
       "type": "timeseries",
       "targets": [
-        { "expr": "sum by (operation) (increase(repo_guard_githubteam_operations{state=\"complete\", organization=~\"$org\", team=~\"$team\"}[5m])) + sum by (operation) (increase(repo_guard_githuborganization_operations{scope=\"owners\", state=\"complete\", github=~\"$github\", organization=~\"$org\"}[5m]))", "legendFormat": "Member {{operation}}", "refId": "A" }
+        {
+          "expr": "sum by (operation) (increase(repo_guard_githubteam_operations{state=\"complete\", organization=~\"$org\", team=~\"$team\"}[5m])) + sum by (operation) (increase(repo_guard_githuborganization_operations{scope=\"owners\", state=\"complete\", github=~\"$github\", organization=~\"$org\"}[5m]))",
+          "legendFormat": "Member {{operation}}",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
       "id": 35,
-      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "title": "🏢 Org Operations (Teams, Repos, Members & Collaborators) (Line Chart)",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "title": "\ud83c\udfe2 Org Operations (Teams, Repos, Members & Collaborators) (Line Chart)",
       "type": "timeseries",
       "targets": [
-        { "expr": "sum by (scope, operation) (increase(repo_guard_githuborganization_operations{scope=~\"teams|repos|orgmembers|repocollaborators\", state=\"complete\", github=~\"$github\", organization=~\"$org\"}[5m]))", "legendFormat": "{{scope}} {{operation}}", "refId": "A" }
+        {
+          "expr": "sum by (scope, operation) (increase(repo_guard_githuborganization_operations{scope=~\"teams|repos|orgmembers|repocollaborators\", state=\"complete\", github=~\"$github\", organization=~\"$org\"}[5m]))",
+          "legendFormat": "{{scope}} {{operation}}",
+          "refId": "A"
+        }
       ]
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
       "id": 400,
       "panels": [],
-      "title": "💡 Insights & Potential Issues",
+      "title": "\ud83d\udca1 Insights & Potential Issues",
       "type": "row"
     },
     {
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           }
         }
       },
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 24 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 24
+      },
       "id": 40,
-      "options": { "colorMode": "background", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value_and_name" },
-      "title": "📡 API Errors",
+      "options": {
+        "colorMode": "background",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name"
+      },
+      "title": "\ud83d\udce1 API Errors",
       "type": "stat",
       "targets": [
-        { "expr": "sum(increase(repo_guard_external_api_requests_total{status=~\"error|[45]..\"}[1h])) or vector(0)", "refId": "A" }
+        {
+          "expr": "sum(increase(repo_guard_external_api_requests_total{status=~\"error|[45]..\"}[1h])) or vector(0)",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "orange", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
             ]
           }
         }
       },
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 24 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 24
+      },
       "id": 41,
-      "options": { "colorMode": "value", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value_and_name" },
-      "title": "🚦 Rate Limit Status",
+      "options": {
+        "colorMode": "value",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name"
+      },
+      "title": "\ud83d\udea6 Rate Limit Status",
       "type": "stat",
       "targets": [
-        { "expr": "sum(repo_guard_githuborganization_status{status=\"ratelimited\", github=~\"$github\", organization=~\"$org\"} == 1) or vector(0)", "refId": "A" }
+        {
+          "expr": "sum(repo_guard_githuborganization_status{status=\"ratelimited\", github=~\"$github\", organization=~\"$org\"} == 1) or vector(0)",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
       "id": 42,
-      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "title": "📡 API Error Rates",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "title": "\ud83d\udce1 API Error Rates",
       "type": "timeseries",
       "targets": [
-        { "expr": "sum by (status) (increase(repo_guard_external_api_requests_total{status!~\"2..|3..|success\"}[5m]))", "legendFormat": "HTTP {{status}}", "refId": "A" }
+        {
+          "expr": "sum by (status) (increase(repo_guard_external_api_requests_total{status!~\"2..|3..|success\"}[5m]))",
+          "legendFormat": "HTTP {{status}}",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "gridPos": { "h": 4, "w": 12, "x": 0, "y": 28 },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
       "id": 43,
-      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "title": "⏱️ Reconcile Duration (p95)",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "title": "\u23f1\ufe0f Reconcile Duration (p95)",
       "type": "timeseries",
       "targets": [
-        { "expr": "histogram_quantile(0.95, sum by (le, controller) (rate(repo_guard_controller_reconcile_duration_seconds_bucket[5m])))", "legendFormat": "{{controller}} p95", "refId": "A" }
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, controller) (rate(repo_guard_controller_reconcile_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{controller}} p95",
+          "refId": "A"
+        }
       ]
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
       "id": 500,
       "panels": [],
-      "title": "📋 Full Status Overview",
+      "title": "\ud83d\udccb Full Status Overview",
       "type": "row"
     },
     {
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "custom": { "align": "auto", "displayMode": "color-background-status" },
+          "custom": {
+            "align": "auto",
+            "displayMode": "color-background-status"
+          },
           "mappings": [
-            { "options": { "failed": { "color": "red", "index": 0 }, "ratelimited": { "color": "yellow", "index": 1 }, "pending": { "color": "orange", "index": 2 }, "complete": { "color": "green", "index": 3 } }, "type": "value" }
+            {
+              "options": {
+                "failed": {
+                  "color": "red",
+                  "index": 0
+                },
+                "ratelimited": {
+                  "color": "yellow",
+                  "index": 1
+                },
+                "pending": {
+                  "color": "orange",
+                  "index": 2
+                },
+                "complete": {
+                  "color": "green",
+                  "index": 3
+                }
+              },
+              "type": "value"
+            }
           ]
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "organization" }, "properties": [ { "id": "custom.width", "value": 200 } ] },
-          { "matcher": { "id": "byName", "options": "status" }, "properties": [ { "id": "custom.width", "value": 150 } ] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "organization"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 200
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
       "id": 50,
-      "options": { "footer": { "show": false }, "showHeader": true },
-      "title": "🏢 Organizations Status",
+      "options": {
+        "footer": {
+          "show": false
+        },
+        "showHeader": true
+      },
+      "title": "\ud83c\udfe2 Organizations Status",
       "type": "table",
       "targets": [
-        { "expr": "sum by (github, organization, status) (repo_guard_githuborganization_status{github=~\"$github\", organization=~\"$org\"} == 1)", "format": "table", "instant": true, "refId": "A" }
+        {
+          "expr": "sum by (github, organization, status) (repo_guard_githuborganization_status{github=~\"$github\", organization=~\"$org\"} == 1)",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "custom": { "align": "auto", "displayMode": "color-background-status" },
+          "custom": {
+            "align": "auto",
+            "displayMode": "color-background-status"
+          },
           "mappings": [
-            { "options": { "failed": { "color": "red", "index": 0 }, "ratelimited": { "color": "yellow", "index": 1 }, "pending": { "color": "orange", "index": 2 }, "complete": { "color": "green", "index": 3 } }, "type": "value" }
+            {
+              "options": {
+                "failed": {
+                  "color": "red",
+                  "index": 0
+                },
+                "ratelimited": {
+                  "color": "yellow",
+                  "index": 1
+                },
+                "pending": {
+                  "color": "orange",
+                  "index": 2
+                },
+                "complete": {
+                  "color": "green",
+                  "index": 3
+                }
+              },
+              "type": "value"
+            }
           ]
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "organization" }, "properties": [ { "id": "custom.width", "value": 150 } ] },
-          { "matcher": { "id": "byName", "options": "team" }, "properties": [ { "id": "custom.width", "value": 250 } ] },
-          { "matcher": { "id": "byName", "options": "status" }, "properties": [ { "id": "custom.width", "value": 150 } ] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "organization"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "team"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "status"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
       "id": 51,
-      "options": { "footer": { "show": false }, "showHeader": true },
-      "title": "👥 Teams Status",
+      "options": {
+        "footer": {
+          "show": false
+        },
+        "showHeader": true
+      },
+      "title": "\ud83d\udc65 Teams Status",
       "type": "table",
       "targets": [
-        { "expr": "sum by (organization, team, status) (repo_guard_githubteam_status{organization=~\"$org\", team=~\"$team\"} == 1)", "format": "table", "instant": true, "refId": "A" }
+        {
+          "expr": "sum by (organization, team, status) (repo_guard_githubteam_status{organization=~\"$org\", team=~\"$team\"} == 1)",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
       ]
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 41 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
       "id": 600,
       "panels": [],
-      "title": "📊 Domain Metrics",
+      "title": "\ud83d\udcca Domain Metrics",
       "type": "row"
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] } } },
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 42 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 42
+      },
       "id": 601,
-      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value_and_name" },
-      "title": "🏢 Managed Teams",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name"
+      },
+      "title": "\ud83c\udfe2 Managed Teams",
       "type": "stat",
       "targets": [
-        { "expr": "sum by (organization) (repo_guard_githuborganization_managed_teams_total{github=~\"$github\", organization=~\"$org\"})", "legendFormat": "{{organization}}", "refId": "A" }
+        {
+          "expr": "sum by (organization) (repo_guard_githuborganization_managed_teams_total{github=~\"$github\", organization=~\"$org\"})",
+          "legendFormat": "{{organization}}",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" } } },
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 42 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 42
+      },
       "id": 602,
-      "options": { "displayMode": "gradient", "orientation": "horizontal", "reduceOptions": { "calcs": ["lastNotNull"] }, "text": {}, "valueMode": "color" },
-      "title": "📁 Managed Repos by Visibility",
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "text": {},
+        "valueMode": "color"
+      },
+      "title": "\ud83d\udcc1 Managed Repos by Visibility",
       "type": "bargauge",
       "targets": [
-        { "expr": "sum by (organization, visibility) (repo_guard_githuborganization_managed_repos_total{github=~\"$github\", organization=~\"$org\"})", "legendFormat": "{{organization}} / {{visibility}}", "refId": "A" }
+        {
+          "expr": "sum by (organization, visibility) (repo_guard_githuborganization_managed_repos_total{github=~\"$github\", organization=~\"$org\"})",
+          "legendFormat": "{{organization}} / {{visibility}}",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] } } },
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 42 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 42
+      },
       "id": 603,
-      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value_and_name" },
-      "title": "👥 Managed Members",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name"
+      },
+      "title": "\ud83d\udc65 Managed Members",
       "type": "stat",
       "targets": [
-        { "expr": "sum by (organization) (repo_guard_githubteam_managed_members_total{organization=~\"$org\"})", "legendFormat": "{{organization}}", "refId": "A" }
+        {
+          "expr": "sum by (organization) (repo_guard_githubteam_managed_members_total{organization=~\"$org\"})",
+          "legendFormat": "{{organization}}",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 46 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 46
+      },
       "id": 604,
-      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "title": "⏳ Pending Operations Total",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "title": "\u23f3 Pending Operations Total",
       "type": "timeseries",
       "targets": [
-        { "expr": "repo_guard_githuborganization_pending_operations_total{github=~\"$github\", organization=~\"$org\"}", "legendFormat": "{{organization}}", "refId": "A" }
+        {
+          "expr": "repo_guard_githuborganization_pending_operations_total{github=~\"$github\", organization=~\"$org\"}",
+          "legendFormat": "{{organization}}",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 46 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 46
+      },
       "id": 605,
-      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "title": "🚫 Sync Failures Rate (org)",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "title": "\ud83d\udeab Sync Failures Rate (org)",
       "type": "timeseries",
       "targets": [
-        { "expr": "rate(repo_guard_githuborganization_sync_failures_total{github=~\"$github\", organization=~\"$org\"}[5m])", "legendFormat": "{{organization}} / {{scope}}", "refId": "A" }
+        {
+          "expr": "rate(repo_guard_githuborganization_sync_failures_total{github=~\"$github\", organization=~\"$org\"}[5m])",
+          "legendFormat": "{{organization}} / {{scope}}",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 54 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 54
+      },
       "id": 606,
-      "options": { "legend": { "displayMode": "table", "placement": "bottom" }, "tooltip": { "mode": "multi" } },
-      "title": "🚦 Rate-Limit Hits",
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "title": "\ud83d\udea6 Rate-Limit Hits",
       "type": "timeseries",
       "targets": [
-        { "expr": "increase(repo_guard_github_ratelimit_hits_total[1h])", "legendFormat": "{{controller}} / {{type}}", "refId": "A" }
+        {
+          "expr": "increase(repo_guard_github_ratelimit_hits_total[1h])",
+          "legendFormat": "{{controller}} / {{type}}",
+          "refId": "A"
+        }
       ]
     },
     {
       "datasource": "${DS_PROMETHEUS}",
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 300 }, { "color": "red", "value": 1800 } ] }, "unit": "s" } },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 54 },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 300
+              },
+              {
+                "color": "red",
+                "value": 1800
+              }
+            ]
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 54
+      },
       "id": 607,
-      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": { "calcs": ["lastNotNull"] }, "textMode": "value_and_name" },
-      "title": "⏱️ Rate-Limit Backoff p95",
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name"
+      },
+      "title": "\u23f1\ufe0f Rate-Limit Backoff p95",
       "type": "stat",
       "targets": [
-        { "expr": "histogram_quantile(0.95, sum by (le) (rate(repo_guard_github_ratelimit_backoff_seconds_bucket[1h])))", "legendFormat": "p95 backoff", "refId": "A" }
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(repo_guard_github_ratelimit_backoff_seconds_bucket[1h])))",
+          "legendFormat": "p95 backoff",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "id": 700,
+      "title": "\ud83d\ude80 GitHub API Efficiency",
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 63
+      },
+      "id": 701,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "title": "\u26a1 GraphQL Calls per Hour",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "increase(repo_guard_github_graphql_calls_total{organization=~\"$org\"}[1h])",
+          "legendFormat": "{{organization}} / {{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 63
+      },
+      "id": 702,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "title": "\ud83d\udce6 ETag Cache \u2014 Hits vs Misses per Hour",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])",
+          "legendFormat": "hit \u00b7 {{organization}} / {{endpoint}}",
+          "refId": "A"
+        },
+        {
+          "expr": "increase(repo_guard_github_etag_cache_misses_total{organization=~\"$org\"}[1h])",
+          "legendFormat": "miss \u00b7 {{organization}} / {{endpoint}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "max": 1,
+          "min": 0
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 63
+      },
+      "id": 703,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "textMode": "value_and_name"
+      },
+      "title": "\ud83d\udcc8 ETag Cache Hit Ratio",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) / (sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) + sum(increase(repo_guard_github_etag_cache_misses_total{organization=~\"$org\"}[1h])))",
+          "legendFormat": "hit ratio",
+          "refId": "A"
+        }
       ]
     }
   ],
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["repoguard", "github"],
+  "tags": [
+    "repoguard",
+    "github"
+  ],
   "templating": {
     "list": [
-      { "name": "DS_PROMETHEUS", "query": "prometheus", "refresh": 1, "type": "datasource" },
-      { "name": "github", "datasource": "${DS_PROMETHEUS}", "query": "label_values(repo_guard_githuborganization_status, github)", "refresh": 1, "type": "query", "multi": true, "includeAll": true, "current": { "text": "All", "value": ["$__all"] } },
-      { "name": "org", "datasource": "${DS_PROMETHEUS}", "query": "label_values(repo_guard_githuborganization_status, organization)", "refresh": 1, "type": "query", "multi": true, "includeAll": true, "current": { "text": "All", "value": ["$__all"] } },
-      { "name": "team", "datasource": "${DS_PROMETHEUS}", "query": "label_values(repo_guard_githubteam_status, team)", "refresh": 1, "type": "query", "multi": true, "includeAll": true, "current": { "text": "All", "value": ["$__all"] } }
+      {
+        "name": "DS_PROMETHEUS",
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      },
+      {
+        "name": "github",
+        "datasource": "${DS_PROMETHEUS}",
+        "query": "label_values(repo_guard_githuborganization_status, github)",
+        "refresh": 1,
+        "type": "query",
+        "multi": true,
+        "includeAll": true,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        }
+      },
+      {
+        "name": "org",
+        "datasource": "${DS_PROMETHEUS}",
+        "query": "label_values(repo_guard_githuborganization_status, organization)",
+        "refresh": 1,
+        "type": "query",
+        "multi": true,
+        "includeAll": true,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        }
+      },
+      {
+        "name": "team",
+        "datasource": "${DS_PROMETHEUS}",
+        "query": "label_values(repo_guard_githubteam_status, team)",
+        "refresh": 1,
+        "type": "query",
+        "multi": true,
+        "includeAll": true,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        }
+      }
     ]
   },
-  "time": { "from": "now-24h", "to": "now" },
-  "title": "Repo Guard • Status & Operations",
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "title": "Repo Guard \u2022 Status & Operations",
   "uid": "repoguard-status-ops",
   "version": 2
 }

--- a/dashboards/repoguard-status-ops-plutono.json
+++ b/dashboards/repoguard-status-ops-plutono.json
@@ -1407,7 +1407,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) / (sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) + sum(increase(repo_guard_github_etag_cache_misses_total{organization=~\"$org\"}[1h])))",
+          "expr": "sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) / clamp_min(sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) + sum(increase(repo_guard_github_etag_cache_misses_total{organization=~\"$org\"}[1h])), 1)",
           "legendFormat": "hit ratio",
           "refId": "A"
         }

--- a/dashboards/repoguard-status-ops-plutono.json
+++ b/dashboards/repoguard-status-ops-plutono.json
@@ -1317,7 +1317,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "increase(repo_guard_github_graphql_calls_total{organization=~\"$org\"}[1h])",
+          "expr": "increase(repo_guard_github_graphql_calls_total{github=~\"$github\",organization=~\"$org\"}[1h])",
           "legendFormat": "{{organization}} / {{result}}",
           "refId": "A"
         }
@@ -1345,12 +1345,12 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])",
+          "expr": "increase(repo_guard_github_etag_cache_hits_total{github=~\"$github\",organization=~\"$org\"}[1h])",
           "legendFormat": "hit \u00b7 {{organization}} / {{endpoint}}",
           "refId": "A"
         },
         {
-          "expr": "increase(repo_guard_github_etag_cache_misses_total{organization=~\"$org\"}[1h])",
+          "expr": "increase(repo_guard_github_etag_cache_misses_total{github=~\"$github\",organization=~\"$org\"}[1h])",
           "legendFormat": "miss \u00b7 {{organization}} / {{endpoint}}",
           "refId": "B"
         }
@@ -1407,7 +1407,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) / clamp_min(sum(increase(repo_guard_github_etag_cache_hits_total{organization=~\"$org\"}[1h])) + sum(increase(repo_guard_github_etag_cache_misses_total{organization=~\"$org\"}[1h])), 1)",
+          "expr": "sum(increase(repo_guard_github_etag_cache_hits_total{github=~\"$github\",organization=~\"$org\"}[1h])) / clamp_min(sum(increase(repo_guard_github_etag_cache_hits_total{github=~\"$github\",organization=~\"$org\"}[1h])) + sum(increase(repo_guard_github_etag_cache_misses_total{github=~\"$github\",organization=~\"$org\"}[1h])), 1)",
           "legendFormat": "hit ratio",
           "refId": "A"
         }

--- a/hack/email-domain-checker/main.go
+++ b/hack/email-domain-checker/main.go
@@ -224,7 +224,7 @@ func main() {
 	}
 
 	// Create UsersProvider and run the check
-	usersProvider, err := ghusers.NewUsersProvider(cc, installationID)
+	usersProvider, err := ghusers.NewUsersProvider(cc, webURL, installationID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create users provider: %v\n", err)
 		os.Exit(6)

--- a/internal/controller/github_controller.go
+++ b/internal/controller/github_controller.go
@@ -172,7 +172,11 @@ func (r *GithubReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // deriveV4APIURL derives the GraphQL (v4) endpoint from the REST (v3) API URL.
 // For GHE:     https://ghe.example.com/api/v3/  → https://ghe.example.com/api/graphql
 // For github.com: https://api.github.com/        → https://api.github.com/graphql
+// Returns "" when v3 is empty so go-githubapp can apply its own defaults.
 func deriveV4APIURL(v3 string) string {
+	if v3 == "" {
+		return ""
+	}
 	if strings.HasSuffix(v3, "/api/v3/") {
 		return strings.TrimSuffix(v3, "/api/v3/") + "/api/graphql"
 	}

--- a/internal/controller/github_controller.go
+++ b/internal/controller/github_controller.go
@@ -6,6 +6,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/palantir/go-githubapp/githubapp"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -90,6 +91,7 @@ func (r *GithubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	cfg := githubapp.Config{
 		WebURL:   github.Spec.WebURL,
 		V3APIURL: github.Spec.V3APIURL,
+		V4APIURL: deriveV4APIURL(github.Spec.V3APIURL),
 	}
 	cfg.App.IntegrationID = github.Spec.IntegrationID
 
@@ -165,4 +167,17 @@ func (r *GithubReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&repoguardsapv1.Github{}).
 		Complete(r)
+}
+
+// deriveV4APIURL derives the GraphQL (v4) endpoint from the REST (v3) API URL.
+// For GHE:     https://ghe.example.com/api/v3/  → https://ghe.example.com/api/graphql
+// For github.com: https://api.github.com/        → https://api.github.com/graphql
+func deriveV4APIURL(v3 string) string {
+	if strings.HasSuffix(v3, "/api/v3/") {
+		return strings.TrimSuffix(v3, "/api/v3/") + "/api/graphql"
+	}
+	if strings.HasSuffix(v3, "/api/v3") {
+		return strings.TrimSuffix(v3, "/api/v3") + "/api/graphql"
+	}
+	return strings.TrimSuffix(v3, "/") + "/graphql"
 }

--- a/internal/controller/githubaccountlink_controller.go
+++ b/internal/controller/githubaccountlink_controller.go
@@ -173,7 +173,7 @@ func (r *GithubAccountLinkReconciler) Reconcile(ctx context.Context, req ctrl.Re
 					minRequeueAfter = 10 * time.Second
 				}
 			} else {
-				usersProvider, err := github.NewUsersProvider(githubClient, installationID)
+				usersProvider, err := github.NewUsersProvider(githubClient, githubName, installationID)
 				if err != nil {
 					l.Error(err, "error during creating the users provider")
 					return ctrl.Result{}, err

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -356,19 +356,19 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return reconcile.Result{RequeueAfter: time.Second}, nil
 	}
 
-	reposProvider, err := github.NewRepositoryProvider(githubClient, githubOrganizationName, githubOrganization.Spec.InstallationID)
+	reposProvider, err := github.NewRepositoryProvider(githubClient, githubName, githubOrganizationName, githubOrganization.Spec.InstallationID)
 	if err != nil {
 		l.Error(err, "error during creating the repository provider")
 		return reconcile.Result{}, err
 	}
 
-	organizationsProvider, err := github.NewOrganizationProvider(githubClient, githubOrganizationName, githubOrganization.Spec.InstallationID)
+	organizationsProvider, err := github.NewOrganizationProvider(githubClient, githubName, githubOrganizationName, githubOrganization.Spec.InstallationID)
 	if err != nil {
 		l.Error(err, "error during creating the organizations provider")
 		return reconcile.Result{}, err
 	}
 
-	teamsProvider, err := github.NewTeamsProvider(githubClient, githubOrganizationName, githubOrganization.Spec.InstallationID)
+	teamsProvider, err := github.NewTeamsProvider(githubClient, githubName, githubOrganizationName, githubOrganization.Spec.InstallationID)
 	if err != nil {
 		l.Error(err, "error during creating the teams provider")
 		return reconcile.Result{}, err

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -474,7 +474,7 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 			return reconcile.Result{}, nil
 		}
 
-		publicRepos, privateRepos, internalRepos, err := reposProvider.ExtendedList(ctx)
+		publicRepos, privateRepos, internalRepos, err := reposProvider.ExtendedListGraphQL(ctx)
 		if err != nil {
 			l.Error(err, "error listing repositories from github")
 			if t, ok := parseGitHubRateLimitReset(err.Error()); ok {

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -448,7 +448,7 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return reconcile.Result{}, err
 	}
 
-	usersProvider, err := github.NewUsersProvider(githubClient, githubOrganization.Spec.InstallationID)
+	usersProvider, err := github.NewUsersProvider(githubClient, githubName, githubOrganization.Spec.InstallationID)
 	if err != nil {
 		l.Error(err, "error during creating the users provider")
 		return reconcile.Result{}, err

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -442,7 +442,7 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
-	teamsProvider, err := github.NewTeamsProvider(githubClient, githubOrgName, githubOrganization.Spec.InstallationID)
+	teamsProvider, err := github.NewTeamsProvider(githubClient, githubName, githubOrgName, githubOrganization.Spec.InstallationID)
 	if err != nil {
 		l.Error(err, "error during creating the teams provider")
 		return reconcile.Result{}, err

--- a/internal/controller/suite_mock_test.go
+++ b/internal/controller/suite_mock_test.go
@@ -94,6 +94,8 @@ func startMockGitHubServer() {
 
 	// Override V3 API URL so the GithubReconciler points go-githubapp at the mock.
 	TEST_ENV["GITHUB_V3_API_URL"] = mockGitHubServer.URL + "/api/v3/"
+	// Override V4 (GraphQL) API URL so ExtendedListGraphQL hits the mock server.
+	TEST_ENV["GITHUB_V4_API_URL"] = mockGitHubServer.URL + "/api/graphql"
 	// Generate a throwaway private key so go-githubapp can build valid JWTs.
 	// The mock server accepts requests without validating the JWT signature.
 	TEST_ENV["GITHUB_PRIVATE_KEY"] = generateMockPrivateKey()

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -33,6 +33,9 @@ func elementsMatch(listA, listB any) bool {
 //   - Invitation rate limit (no timestamp): "exceeded the organization invitation rate limit …"
 //     → returns a synthetic backoff of now+1h (the API does not provide a reset time for this case).
 //
+//   - GraphQL secondary rate limit: "You have exceeded a secondary rate limit" / "API rate limit exceeded for installation ID"
+//     → treated as a rate-limit error and returns now+1h as a conservative backoff.
+//
 // Returns the retry-after time in UTC and true if the error is a recognisable rate-limit error;
 // otherwise returns zero time and false.
 func parseGitHubRateLimitReset(errStr string) (time.Time, bool) {
@@ -57,6 +60,11 @@ func parseGitHubRateLimitReset(errStr string) (time.Time, bool) {
 		return time.Now().UTC(), true
 	}
 	if !strings.Contains(lowered, "until ") {
+		// GraphQL secondary rate limit strings (no timestamp): treat as rate-limited with 1h backoff.
+		if strings.Contains(lowered, "secondary rate limit") ||
+			strings.Contains(lowered, "api rate limit exceeded for installation") {
+			return time.Now().UTC().Add(time.Hour), true
+		}
 		return time.Time{}, false
 	}
 	// Format 1: extract the future reset timestamp after "until ".

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -64,4 +64,29 @@ func TestParseGitHubRateLimitReset(t *testing.T) {
 			t.Fatal("expected ok=false for empty string")
 		}
 	})
+
+	t.Run("graphql secondary rate limit returns conservative backoff", func(t *testing.T) {
+		errStr := "You have exceeded a secondary rate limit. Please wait a few minutes before you try again."
+		before := time.Now().UTC()
+		got, ok := parseGitHubRateLimitReset(errStr)
+		if !ok {
+			t.Fatal("expected ok=true for GraphQL secondary rate limit, got false")
+		}
+		if !got.After(before) {
+			t.Fatalf("expected future backoff time, got %v (before=%v)", got, before)
+		}
+	})
+
+	t.Run("graphql installation rate limit without timestamp returns backoff", func(t *testing.T) {
+		// GraphQL errors: no "until" timestamp, just a generic installation rate limit.
+		errStr := "API rate limit exceeded for installation ID 99999."
+		before := time.Now().UTC()
+		got, ok := parseGitHubRateLimitReset(errStr)
+		if !ok {
+			t.Fatal("expected ok=true for GraphQL installation rate limit, got false")
+		}
+		if !got.After(before) {
+			t.Fatalf("expected future backoff time, got %v (before=%v)", got, before)
+		}
+	})
 }

--- a/internal/github/etag_cache.go
+++ b/internal/github/etag_cache.go
@@ -56,6 +56,18 @@ func (c *etagCache) set(key string, etag string, value any) {
 	c.entries[key] = etagEntry{etag: etag, value: value}
 }
 
+// setEtagOnly updates the ETag for the given cache key while preserving any
+// previously cached parsed value. This is used by the transport layer on 200
+// responses so that a provider-cached value is not lost before the provider
+// has a chance to re-store it.
+func (c *etagCache) setEtagOnly(key string, etag string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e := c.entries[key]
+	e.etag = etag
+	c.entries[key] = e
+}
+
 // invalidate removes the entry for the given cache key.
 func (c *etagCache) invalidate(key string) {
 	c.mu.Lock()

--- a/internal/github/etag_cache.go
+++ b/internal/github/etag_cache.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import "sync"
+
+// etagEntry stores an ETag header value and the last-parsed result for a cached resource.
+type etagEntry struct {
+	etag  string
+	value any
+}
+
+// etagCache is a per-organisation cache of ETag entries keyed by an endpoint string.
+type etagCache struct {
+	mu      sync.RWMutex
+	entries map[string]etagEntry
+}
+
+// orgCaches is the package-level map from org name to its *etagCache.
+// It survives across reconcile cycles since providers are re-created on every Reconcile.
+var orgCaches sync.Map // key: string, value: *etagCache
+
+// getOrCreateOrgCache returns the *etagCache for the given org, creating it if necessary.
+func getOrCreateOrgCache(org string) *etagCache {
+	v, _ := orgCaches.LoadOrStore(org, &etagCache{entries: make(map[string]etagEntry)})
+	return v.(*etagCache) //nolint:forcetypeassert
+}
+
+// getEtag returns the stored ETag for the given cache key, if any.
+func (c *etagCache) getEtag(key string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.entries[key]
+	if !ok {
+		return "", false
+	}
+	return e.etag, true
+}
+
+// getValue returns the stored parsed value for the given cache key, if any.
+func (c *etagCache) getValue(key string) (any, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	return e.value, true
+}
+
+// set stores the ETag and parsed value for the given cache key.
+func (c *etagCache) set(key string, etag string, value any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = etagEntry{etag: etag, value: value}
+}
+
+// invalidate removes the entry for the given cache key.
+func (c *etagCache) invalidate(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, key)
+}

--- a/internal/github/etag_cache.go
+++ b/internal/github/etag_cache.go
@@ -21,9 +21,12 @@ type etagCache struct {
 // It survives across reconcile cycles since providers are re-created on every Reconcile.
 var orgCaches sync.Map // key: string, value: *etagCache
 
-// getOrCreateOrgCache returns the *etagCache for the given org, creating it if necessary.
-func getOrCreateOrgCache(org string) *etagCache {
-	v, _ := orgCaches.LoadOrStore(org, &etagCache{entries: make(map[string]etagEntry)})
+// getOrCreateOrgCache returns the *etagCache for the given github+org pair, creating it if necessary.
+// The key is "<github>|<org>" to avoid collisions when multiple GitHub instances manage
+// organisations with the same name.
+func getOrCreateOrgCache(githubName, org string) *etagCache {
+	key := githubName + "|" + org
+	v, _ := orgCaches.LoadOrStore(key, &etagCache{entries: make(map[string]etagEntry)})
 	return v.(*etagCache) //nolint:forcetypeassert
 }
 

--- a/internal/github/etag_cache_test.go
+++ b/internal/github/etag_cache_test.go
@@ -67,18 +67,27 @@ func TestEtagCache_ConcurrentAccess(t *testing.T) {
 }
 
 func TestGetOrCreateOrgCache_SameInstance(t *testing.T) {
-	// Two calls for the same org must return the same pointer.
-	a := getOrCreateOrgCache("org-cache-test")
-	b := getOrCreateOrgCache("org-cache-test")
+	// Two calls for the same github+org must return the same pointer.
+	a := getOrCreateOrgCache("gh1", "org-cache-test")
+	b := getOrCreateOrgCache("gh1", "org-cache-test")
 	if a != b {
-		t.Error("expected same *etagCache for same org")
+		t.Error("expected same *etagCache for same github+org")
 	}
 }
 
 func TestGetOrCreateOrgCache_DifferentOrgs(t *testing.T) {
-	a := getOrCreateOrgCache("org-cache-test-alpha")
-	b := getOrCreateOrgCache("org-cache-test-beta")
+	a := getOrCreateOrgCache("gh1", "org-cache-test-alpha")
+	b := getOrCreateOrgCache("gh1", "org-cache-test-beta")
 	if a == b {
 		t.Error("expected different *etagCache for different orgs")
+	}
+}
+
+func TestGetOrCreateOrgCache_DifferentGithubInstances(t *testing.T) {
+	// Same org name under different GitHub instances must not share cache.
+	a := getOrCreateOrgCache("gh-instance-a", "shared-org")
+	b := getOrCreateOrgCache("gh-instance-b", "shared-org")
+	if a == b {
+		t.Error("expected different *etagCache for same org on different github instances")
 	}
 }

--- a/internal/github/etag_cache_test.go
+++ b/internal/github/etag_cache_test.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestEtagCache_SetAndGet(t *testing.T) {
+	c := &etagCache{entries: make(map[string]etagEntry)}
+
+	// Nothing stored yet.
+	if _, ok := c.getEtag("k"); ok {
+		t.Fatal("expected no etag before set")
+	}
+	if _, ok := c.getValue("k"); ok {
+		t.Fatal("expected no value before set")
+	}
+
+	c.set("k", `"abc"`, []string{"a", "b"})
+
+	etag, ok := c.getEtag("k")
+	if !ok {
+		t.Fatal("expected etag after set")
+	}
+	if etag != `"abc"` {
+		t.Errorf("etag: got %q, want %q", etag, `"abc"`)
+	}
+
+	val, ok := c.getValue("k")
+	if !ok {
+		t.Fatal("expected value after set")
+	}
+	s, _ := val.([]string)
+	if len(s) != 2 || s[0] != "a" {
+		t.Errorf("value: got %v", val)
+	}
+}
+
+func TestEtagCache_Invalidate(t *testing.T) {
+	c := &etagCache{entries: make(map[string]etagEntry)}
+	c.set("k", `"x"`, "some-value")
+
+	c.invalidate("k")
+
+	if _, ok := c.getEtag("k"); ok {
+		t.Error("expected no etag after invalidate")
+	}
+}
+
+func TestEtagCache_ConcurrentAccess(t *testing.T) {
+	c := &etagCache{entries: make(map[string]etagEntry)}
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			key := "k"
+			c.set(key, `"etag"`, n)
+			c.getEtag(key)  //nolint:errcheck
+			c.getValue(key) //nolint:errcheck
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestGetOrCreateOrgCache_SameInstance(t *testing.T) {
+	// Two calls for the same org must return the same pointer.
+	a := getOrCreateOrgCache("org-cache-test")
+	b := getOrCreateOrgCache("org-cache-test")
+	if a != b {
+		t.Error("expected same *etagCache for same org")
+	}
+}
+
+func TestGetOrCreateOrgCache_DifferentOrgs(t *testing.T) {
+	a := getOrCreateOrgCache("org-cache-test-alpha")
+	b := getOrCreateOrgCache("org-cache-test-beta")
+	if a == b {
+		t.Error("expected different *etagCache for different orgs")
+	}
+}

--- a/internal/github/etag_transport.go
+++ b/internal/github/etag_transport.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"net/http"
+)
+
+// etagTransport is an http.RoundTripper that injects If-None-Match headers on
+// outbound GET requests and stores new ETags from 200 responses.
+// The actual cached value (parsed response body) is stored by the provider layer.
+type etagTransport struct {
+	wrapped http.RoundTripper
+	cache   *etagCache
+	keyFn   func(*http.Request) string
+}
+
+// RoundTrip implements http.RoundTripper.
+// For GET requests:
+//   - If a cached ETag exists for the key derived from the request, adds If-None-Match.
+//   - On 200 responses, stores the new ETag so the next request can use it.
+//   - On 304 responses, passes through to the caller; the provider layer handles value retrieval.
+func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Method != http.MethodGet {
+		return t.wrapped.RoundTrip(req)
+	}
+	key := t.keyFn(req)
+	if etag, ok := t.cache.getEtag(key); ok {
+		req = req.Clone(req.Context())
+		req.Header.Set("If-None-Match", etag)
+	}
+	resp, err := t.wrapped.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	if resp.StatusCode == http.StatusOK {
+		if etag := resp.Header.Get("ETag"); etag != "" {
+			// Store the ETag only; the provider stores the parsed value on 200.
+			t.cache.set(key, etag, nil)
+		}
+	}
+	return resp, nil
+}
+
+// urlCacheKey returns a stable string derived from the request URL path and raw query.
+// This is used as the default keyFn for etagTransport.
+func urlCacheKey(req *http.Request) string {
+	if req.URL.RawQuery != "" {
+		return req.URL.Path + "?" + req.URL.RawQuery
+	}
+	return req.URL.Path
+}

--- a/internal/github/etag_transport.go
+++ b/internal/github/etag_transport.go
@@ -36,8 +36,9 @@ func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	if resp.StatusCode == http.StatusOK {
 		if etag := resp.Header.Get("ETag"); etag != "" {
-			// Store the ETag only; the provider stores the parsed value on 200.
-			t.cache.set(key, etag, nil)
+			// Update the ETag while preserving any previously cached parsed value.
+			// The provider layer will overwrite the value on 200 via cache.set().
+			t.cache.setEtagOnly(key, etag)
 		}
 	}
 	return resp, nil

--- a/internal/github/etag_transport.go
+++ b/internal/github/etag_transport.go
@@ -5,6 +5,7 @@ package github
 
 import (
 	"net/http"
+	"strings"
 )
 
 // etagTransport is an http.RoundTripper that injects If-None-Match headers on
@@ -44,11 +45,20 @@ func (t *etagTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
-// urlCacheKey returns a stable string derived from the request URL path and raw query.
+// urlCacheKey returns a stable cache key derived from the request URL path and raw query.
+// It strips the GitHub Enterprise REST prefix ("/api/v3") so that cache keys are
+// consistent with provider-side keys (e.g. "/orgs/...") regardless of whether the
+// target is github.com or a GHE instance.
 // This is used as the default keyFn for etagTransport.
 func urlCacheKey(req *http.Request) string {
-	if req.URL.RawQuery != "" {
-		return req.URL.Path + "?" + req.URL.RawQuery
+	path := req.URL.Path
+	// Normalize GHE paths: strip leading "/api/v3" prefix so cache keys match
+	// provider-constructed keys which always start with "/orgs/", "/repos/", etc.
+	if after, ok := strings.CutPrefix(path, "/api/v3"); ok {
+		path = after
 	}
-	return req.URL.Path
+	if req.URL.RawQuery != "" {
+		return path + "?" + req.URL.RawQuery
+	}
+	return path
 }

--- a/internal/github/etag_transport_test.go
+++ b/internal/github/etag_transport_test.go
@@ -111,6 +111,9 @@ func TestUrlCacheKey(t *testing.T) {
 	}{
 		{"http://example.com/orgs/myorg/members", "/orgs/myorg/members"},
 		{"http://example.com/orgs/myorg/members?role=admin&per_page=100", "/orgs/myorg/members?role=admin&per_page=100"},
+		// GitHub Enterprise paths include /api/v3 prefix; keys must be normalized.
+		{"https://ghe.example.com/api/v3/orgs/myorg/members", "/orgs/myorg/members"},
+		{"https://ghe.example.com/api/v3/repos/myorg/myrepo/teams?per_page=100", "/repos/myorg/myrepo/teams?per_page=100"},
 	}
 	for _, tc := range cases {
 		req, _ := http.NewRequest(http.MethodGet, tc.url, nil)

--- a/internal/github/etag_transport_test.go
+++ b/internal/github/etag_transport_test.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEtagTransport_InjectsIfNoneMatch(t *testing.T) {
+	cache := &etagCache{entries: make(map[string]etagEntry)}
+	cache.set("/repos", `"etag-v1"`, nil)
+
+	var receivedHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeader = r.Header.Get("If-None-Match")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	transport := &etagTransport{
+		wrapped: http.DefaultTransport,
+		cache:   cache,
+		keyFn:   urlCacheKey,
+	}
+	client := &http.Client{Transport: transport}
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/repos", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if receivedHeader != `"etag-v1"` {
+		t.Errorf("If-None-Match: got %q, want %q", receivedHeader, `"etag-v1"`)
+	}
+}
+
+func TestEtagTransport_Stores200Etag(t *testing.T) {
+	cache := &etagCache{entries: make(map[string]etagEntry)}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"new-etag"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	transport := &etagTransport{
+		wrapped: http.DefaultTransport,
+		cache:   cache,
+		keyFn:   urlCacheKey,
+	}
+	client := &http.Client{Transport: transport}
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/resource", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	etag, ok := cache.getEtag("/resource")
+	if !ok {
+		t.Fatal("expected ETag to be stored after 200 response")
+	}
+	if etag != `"new-etag"` {
+		t.Errorf("stored etag: got %q, want %q", etag, `"new-etag"`)
+	}
+}
+
+func TestEtagTransport_SkipsNonGet(t *testing.T) {
+	cache := &etagCache{entries: make(map[string]etagEntry)}
+	cache.set("/resource", `"should-not-inject"`, nil)
+
+	var receivedHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeader = r.Header.Get("If-None-Match")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	transport := &etagTransport{
+		wrapped: http.DefaultTransport,
+		cache:   cache,
+		keyFn:   urlCacheKey,
+	}
+	client := &http.Client{Transport: transport}
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/resource", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() }) //nolint:errcheck
+
+	if receivedHeader != "" {
+		t.Errorf("expected no If-None-Match for POST, got %q", receivedHeader)
+	}
+}
+
+func TestUrlCacheKey(t *testing.T) {
+	cases := []struct {
+		url  string
+		want string
+	}{
+		{"http://example.com/orgs/myorg/members", "/orgs/myorg/members"},
+		{"http://example.com/orgs/myorg/members?role=admin&per_page=100", "/orgs/myorg/members?role=admin&per_page=100"},
+	}
+	for _, tc := range cases {
+		req, _ := http.NewRequest(http.MethodGet, tc.url, nil)
+		got := urlCacheKey(req)
+		if got != tc.want {
+			t.Errorf("urlCacheKey(%q): got %q, want %q", tc.url, got, tc.want)
+		}
+	}
+}

--- a/internal/github/mock_server.go
+++ b/internal/github/mock_server.go
@@ -880,6 +880,76 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 		}
 		writeJSONError(w, `{"message":"Not Found"}`, http.StatusNotFound)
 	})
+
+	// ---- GraphQL ----
+
+	// POST /api/graphql  — serves the orgReposWithTeamsQuery used by ExtendedListGraphQL.
+	// The mock returns all repos in a single page (no pagination) with their team permissions.
+	mux.HandleFunc("/api/graphql", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		stateMu.Lock()
+		snapshot := make([]MockRepo, len(repos))
+		copy(snapshot, repos)
+		stateMu.Unlock()
+
+		nodes := make([]map[string]any, 0, len(snapshot))
+		for _, repo := range snapshot {
+			// Archived and disabled repos are included in the response;
+			// ExtendedListGraphQL itself filters them out (same as REST path).
+			teamEdges := make([]map[string]any, 0, len(repo.Teams))
+			for _, tp := range repo.Teams {
+				teamEdges = append(teamEdges, map[string]any{
+					"permission": restPermissionToGraphQL(tp.Permission),
+					"node":       map[string]any{"slug": tp.Slug},
+				})
+			}
+			nodes = append(nodes, map[string]any{
+				"name":       repo.Name,
+				"visibility": strings.ToUpper(repo.repoVisibility()),
+				"isArchived": repo.Archived,
+				"isDisabled": repo.Disabled,
+				"teams": map[string]any{
+					"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+					"edges":    teamEdges,
+				},
+			})
+		}
+
+		resp := map[string]any{
+			"data": map[string]any{
+				"organization": map[string]any{
+					"repositories": map[string]any{
+						"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+						"nodes":    nodes,
+					},
+				},
+			},
+		}
+		writeJSON(w, resp)
+	})
+}
+
+// restPermissionToGraphQL converts a REST permission string (push, pull, admin, maintain, triage)
+// to the GraphQL RepositoryPermission enum value (WRITE, READ, ADMIN, MAINTAIN, TRIAGE).
+func restPermissionToGraphQL(p string) string {
+	switch p {
+	case "push":
+		return "WRITE"
+	case "pull":
+		return "READ"
+	case "admin":
+		return "ADMIN"
+	case "maintain":
+		return "MAINTAIN"
+	case "triage":
+		return "TRIAGE"
+	default:
+		return strings.ToUpper(p)
+	}
 }
 
 // userToMap converts a MockUser to a JSON-serialisable map with the field

--- a/internal/github/organizations.go
+++ b/internal/github/organizations.go
@@ -192,6 +192,7 @@ func (o *DefaultOrganizationProvider) OwnersExtended(ctx context.Context) ([]Git
 // ListMembers only returns active members, so without this, users whose invite is still pending
 // are invisible to OwnersExtended and get re-invited on every reconcile.
 func (o *DefaultOrganizationProvider) pendingAdminMembers(ctx context.Context) ([]GithubMember, error) {
+	firstPageKey := fmt.Sprintf("/orgs/%s/invitations?per_page=100", o.organization)
 	opt := &gogithub.ListOptions{PerPage: 100}
 
 	result := make([]GithubMember, 0)
@@ -202,6 +203,15 @@ func (o *DefaultOrganizationProvider) pendingAdminMembers(ctx context.Context) (
 			// 404 as "no pending invitations" so reconciliation is not blocked.
 			if resp != nil && resp.StatusCode == 404 {
 				return result, nil
+			}
+			if resp != nil && resp.StatusCode == http.StatusNotModified {
+				if cached, ok := o.cache.getValue(firstPageKey); ok {
+					if v, ok := cached.([]GithubMember); ok {
+						return v, nil
+					}
+				}
+				o.cache.invalidate(firstPageKey)
+				return nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", firstPageKey)
 			}
 			return nil, err
 		}
@@ -226,6 +236,10 @@ func (o *DefaultOrganizationProvider) pendingAdminMembers(ctx context.Context) (
 			break
 		}
 		opt.Page = resp.NextPage
+	}
+
+	if etag, ok := o.cache.getEtag(firstPageKey); ok && etag != "" {
+		o.cache.set(firstPageKey, etag, result)
 	}
 
 	return result, nil

--- a/internal/github/organizations.go
+++ b/internal/github/organizations.go
@@ -128,7 +128,11 @@ func (o *DefaultOrganizationProvider) members(ctx context.Context, role string) 
 
 func (o *DefaultOrganizationProvider) membersExtended(ctx context.Context, role string) ([]GithubMember, error) {
 
-	firstPageKey := fmt.Sprintf("/orgs/%s/members?per_page=100&role=%s", o.organization, role)
+	// etagKey matches the URL used by the transport for If-None-Match injection.
+	// valueKey has a "#ext" suffix to avoid colliding with the members() cache entry
+	// for the same URL, which stores []string (different type).
+	etagKey := fmt.Sprintf("/orgs/%s/members?per_page=100&role=%s", o.organization, role)
+	valueKey := etagKey + "#ext"
 
 	opt := &gogithub.ListMembersOptions{
 		ListOptions: gogithub.ListOptions{PerPage: 100},
@@ -141,13 +145,13 @@ func (o *DefaultOrganizationProvider) membersExtended(ctx context.Context, role 
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusNotModified {
 				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.organization, "org-members-ext").Inc()
-				if cached, ok := o.cache.getValue(firstPageKey); ok {
+				if cached, ok := o.cache.getValue(valueKey); ok {
 					if v, ok := cached.([]GithubMember); ok {
 						return v, nil
 					}
 				}
-				o.cache.invalidate(firstPageKey)
-				return nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", firstPageKey)
+				o.cache.invalidate(valueKey)
+				return nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", valueKey)
 			}
 			return nil, err
 		}
@@ -163,9 +167,9 @@ func (o *DefaultOrganizationProvider) membersExtended(ctx context.Context, role 
 		opt.Page = resp.NextPage
 	}
 
-	if etag, ok := o.cache.getEtag(firstPageKey); ok && etag != "" {
+	if etag, ok := o.cache.getEtag(etagKey); ok && etag != "" {
 		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.organization, "org-members-ext").Inc()
-		o.cache.set(firstPageKey, etag, result)
+		o.cache.set(valueKey, etag, result)
 	}
 
 	return result, nil

--- a/internal/github/organizations.go
+++ b/internal/github/organizations.go
@@ -7,26 +7,29 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
+	gogithub "github.com/google/go-github/v88/github"
 	"github.com/palantir/go-githubapp/githubapp"
 
-	"github.com/google/go-github/v88/github"
+	ghmetrics "github.com/cloudoperators/repo-guard/internal/metrics"
 )
 
 type OrganizationProvider interface {
 	Owners(ctx context.Context) ([]string, error)
 	OwnersExtended(ctx context.Context) ([]GithubMember, error)
 	Members(ctx context.Context) ([]string, error)
-	ExtendedMembers(ctx context.Context) ([]*github.User, []*github.User, error)
+	ExtendedMembers(ctx context.Context) ([]*gogithub.User, []*gogithub.User, error)
 	ChangeToOwner(ctx context.Context, user string) error
 	ChangeToMember(ctx context.Context, user string) error
 	RemoveFromOrg(ctx context.Context, user string) error
 }
 
 type DefaultOrganizationProvider struct {
-	organizationService github.OrganizationsService
-	usersService        github.UsersService
+	organizationService gogithub.OrganizationsService
+	usersService        gogithub.UsersService
 	organization        string
+	cache               *etagCache
 }
 
 // installationID can be found at Organizations - Settings - Installed Github Apps and check the URL
@@ -46,13 +49,40 @@ func NewOrganizationProvider(cc githubapp.ClientCreator, organization string, in
 	if organization == "" {
 		return nil, errors.New("organization name should not be empty")
 	}
-	return &DefaultOrganizationProvider{organizationService: *client.Organizations, usersService: *client.Users, organization: organization}, nil
+
+	cache := getOrCreateOrgCache(organization)
+
+	// Clone the client with an ETag transport for conditional GET caching.
+	baseHTTP := client.Client()
+	baseTransport := baseHTTP.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	etagHTTP := &http.Client{
+		Transport:     &etagTransport{wrapped: baseTransport, cache: cache, keyFn: urlCacheKey},
+		CheckRedirect: baseHTTP.CheckRedirect,
+		Jar:           baseHTTP.Jar,
+		Timeout:       baseHTTP.Timeout,
+	}
+	etagClient, err := client.Clone(gogithub.WithHTTPClient(etagHTTP))
+	if err != nil {
+		return nil, fmt.Errorf("clone github client with etag transport: %w", err)
+	}
+
+	return &DefaultOrganizationProvider{
+		organizationService: *etagClient.Organizations,
+		usersService:        *client.Users, // user lookups use the original client
+		organization:        organization,
+		cache:               cache,
+	}, nil
 }
 
 func (o *DefaultOrganizationProvider) members(ctx context.Context, role string) ([]string, error) {
 
-	opt := &github.ListMembersOptions{
-		ListOptions: github.ListOptions{PerPage: 100},
+	firstPageKey := fmt.Sprintf("/orgs/%s/members?per_page=100&role=%s", o.organization, role)
+
+	opt := &gogithub.ListMembersOptions{
+		ListOptions: gogithub.ListOptions{PerPage: 100},
 		Role:        role,
 	}
 
@@ -60,6 +90,15 @@ func (o *DefaultOrganizationProvider) members(ctx context.Context, role string) 
 	for {
 		users, resp, err := o.organizationService.ListMembers(ctx, o.organization, opt)
 		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotModified {
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.organization, "org-members").Inc()
+				if cached, ok := o.cache.getValue(firstPageKey); ok {
+					if v, ok := cached.([]string); ok {
+						return v, nil
+					}
+				}
+				return []string{}, nil
+			}
 			return nil, err
 		}
 		for _, member := range users {
@@ -78,13 +117,20 @@ func (o *DefaultOrganizationProvider) members(ctx context.Context, role string) 
 		opt.Page = resp.NextPage
 	}
 
+	if etag, ok := o.cache.getEtag(firstPageKey); ok && etag != "" {
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.organization, "org-members").Inc()
+		o.cache.set(firstPageKey, etag, memberList)
+	}
+
 	return memberList, nil
 }
 
 func (o *DefaultOrganizationProvider) membersExtended(ctx context.Context, role string) ([]GithubMember, error) {
 
-	opt := &github.ListMembersOptions{
-		ListOptions: github.ListOptions{PerPage: 100},
+	firstPageKey := fmt.Sprintf("/orgs/%s/members?per_page=100&role=%s", o.organization, role)
+
+	opt := &gogithub.ListMembersOptions{
+		ListOptions: gogithub.ListOptions{PerPage: 100},
 		Role:        role,
 	}
 
@@ -92,6 +138,15 @@ func (o *DefaultOrganizationProvider) membersExtended(ctx context.Context, role 
 	for {
 		users, resp, err := o.organizationService.ListMembers(ctx, o.organization, opt)
 		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotModified {
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.organization, "org-members-ext").Inc()
+				if cached, ok := o.cache.getValue(firstPageKey); ok {
+					if v, ok := cached.([]GithubMember); ok {
+						return v, nil
+					}
+				}
+				return []GithubMember{}, nil
+			}
 			return nil, err
 		}
 		for _, m := range users {
@@ -104,6 +159,11 @@ func (o *DefaultOrganizationProvider) membersExtended(ctx context.Context, role 
 			break
 		}
 		opt.Page = resp.NextPage
+	}
+
+	if etag, ok := o.cache.getEtag(firstPageKey); ok && etag != "" {
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.organization, "org-members-ext").Inc()
+		o.cache.set(firstPageKey, etag, result)
 	}
 
 	return result, nil
@@ -130,7 +190,7 @@ func (o *DefaultOrganizationProvider) OwnersExtended(ctx context.Context) ([]Git
 // ListMembers only returns active members, so without this, users whose invite is still pending
 // are invisible to OwnersExtended and get re-invited on every reconcile.
 func (o *DefaultOrganizationProvider) pendingAdminMembers(ctx context.Context) ([]GithubMember, error) {
-	opt := &github.ListOptions{PerPage: 100}
+	opt := &gogithub.ListOptions{PerPage: 100}
 
 	result := make([]GithubMember, 0)
 	for {
@@ -169,17 +229,29 @@ func (o *DefaultOrganizationProvider) pendingAdminMembers(ctx context.Context) (
 	return result, nil
 }
 
-func (o *DefaultOrganizationProvider) ExtendedMembers(ctx context.Context) ([]*github.User, []*github.User, error) {
+func (o *DefaultOrganizationProvider) ExtendedMembers(ctx context.Context) ([]*gogithub.User, []*gogithub.User, error) {
 
-	optMfa := &github.ListMembersOptions{
-		ListOptions: github.ListOptions{PerPage: 100},
+	mfaKey := fmt.Sprintf("/orgs/%s/members?filter=2fa_disabled&per_page=100&role=all", o.organization)
+	allKey := fmt.Sprintf("/orgs/%s/members?per_page=100&role=all", o.organization)
+
+	optMfa := &gogithub.ListMembersOptions{
+		ListOptions: gogithub.ListOptions{PerPage: 100},
 		Role:        "all",
 		Filter:      "2fa_disabled",
 	}
-	mfadisabled := make([]*github.User, 0)
+	mfadisabled := make([]*gogithub.User, 0)
 	for {
 		users, resp, err := o.organizationService.ListMembers(ctx, o.organization, optMfa)
 		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotModified {
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.organization, "org-members-2fa").Inc()
+				if cached, ok := o.cache.getValue(mfaKey); ok {
+					if v, ok := cached.([]*gogithub.User); ok {
+						mfadisabled = v
+					}
+				}
+				break
+			}
 			return nil, nil, err
 		}
 		mfadisabled = append(mfadisabled, users...)
@@ -188,15 +260,28 @@ func (o *DefaultOrganizationProvider) ExtendedMembers(ctx context.Context) ([]*g
 		}
 		optMfa.Page = resp.NextPage
 	}
+	if etag, ok := o.cache.getEtag(mfaKey); ok && etag != "" {
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.organization, "org-members-2fa").Inc()
+		o.cache.set(mfaKey, etag, mfadisabled)
+	}
 
-	optAll := &github.ListMembersOptions{
-		ListOptions: github.ListOptions{PerPage: 100},
+	optAll := &gogithub.ListMembersOptions{
+		ListOptions: gogithub.ListOptions{PerPage: 100},
 		Role:        "all",
 	}
-	allMembers := make([]*github.User, 0)
+	allMembers := make([]*gogithub.User, 0)
 	for {
 		users, resp, err := o.organizationService.ListMembers(ctx, o.organization, optAll)
 		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotModified {
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.organization, "org-members-all").Inc()
+				if cached, ok := o.cache.getValue(allKey); ok {
+					if v, ok := cached.([]*gogithub.User); ok {
+						allMembers = v
+					}
+				}
+				break
+			}
 			return nil, nil, err
 		}
 		allMembers = append(allMembers, users...)
@@ -204,6 +289,10 @@ func (o *DefaultOrganizationProvider) ExtendedMembers(ctx context.Context) ([]*g
 			break
 		}
 		optAll.Page = resp.NextPage
+	}
+	if etag, ok := o.cache.getEtag(allKey); ok && etag != "" {
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.organization, "org-members-all").Inc()
+		o.cache.set(allKey, etag, allMembers)
 	}
 
 	return allMembers, mfadisabled, nil
@@ -216,7 +305,7 @@ func (o *DefaultOrganizationProvider) Members(ctx context.Context) ([]string, er
 
 func (o *DefaultOrganizationProvider) changeRole(ctx context.Context, user string, role string) error {
 
-	membership := &github.Membership{}
+	membership := &gogithub.Membership{}
 	membership.Role = &role
 
 	_, response, err := o.organizationService.EditOrgMembership(ctx, user, o.organization, membership)

--- a/internal/github/organizations.go
+++ b/internal/github/organizations.go
@@ -29,11 +29,12 @@ type DefaultOrganizationProvider struct {
 	organizationService gogithub.OrganizationsService
 	usersService        gogithub.UsersService
 	organization        string
+	githubName          string
 	cache               *etagCache
 }
 
 // installationID can be found at Organizations - Settings - Installed Github Apps and check the URL
-func NewOrganizationProvider(cc githubapp.ClientCreator, organization string, installationID int64) (OrganizationProvider, error) {
+func NewOrganizationProvider(cc githubapp.ClientCreator, githubName, organization string, installationID int64) (OrganizationProvider, error) {
 
 	client, err := cc.NewInstallationClient(installationID)
 	if err != nil {
@@ -50,7 +51,7 @@ func NewOrganizationProvider(cc githubapp.ClientCreator, organization string, in
 		return nil, errors.New("organization name should not be empty")
 	}
 
-	cache := getOrCreateOrgCache(organization)
+	cache := getOrCreateOrgCache(githubName, organization)
 
 	// Clone the client with an ETag transport for conditional GET caching.
 	baseHTTP := client.Client()
@@ -73,6 +74,7 @@ func NewOrganizationProvider(cc githubapp.ClientCreator, organization string, in
 		organizationService: *etagClient.Organizations,
 		usersService:        *client.Users, // user lookups use the original client
 		organization:        organization,
+		githubName:          githubName,
 		cache:               cache,
 	}, nil
 }
@@ -91,7 +93,7 @@ func (o *DefaultOrganizationProvider) members(ctx context.Context, role string) 
 		users, resp, err := o.organizationService.ListMembers(ctx, o.organization, opt)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusNotModified {
-				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.organization, "org-members").Inc()
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.githubName, o.organization, "org-members").Inc()
 				if cached, ok := o.cache.getValue(firstPageKey); ok {
 					if v, ok := cached.([]string); ok {
 						return v, nil
@@ -119,7 +121,7 @@ func (o *DefaultOrganizationProvider) members(ctx context.Context, role string) 
 	}
 
 	if etag, ok := o.cache.getEtag(firstPageKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.organization, "org-members").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.githubName, o.organization, "org-members").Inc()
 		o.cache.set(firstPageKey, etag, memberList)
 	}
 
@@ -144,13 +146,16 @@ func (o *DefaultOrganizationProvider) membersExtended(ctx context.Context, role 
 		users, resp, err := o.organizationService.ListMembers(ctx, o.organization, opt)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusNotModified {
-				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.organization, "org-members-ext").Inc()
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.githubName, o.organization, "org-members-ext").Inc()
 				if cached, ok := o.cache.getValue(valueKey); ok {
 					if v, ok := cached.([]GithubMember); ok {
 						return v, nil
 					}
 				}
+				// Invalidate both the value key and the ETag key so the transport
+				// stops injecting If-None-Match and forces a fresh 200 on the next call.
 				o.cache.invalidate(valueKey)
+				o.cache.invalidate(etagKey)
 				return nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", valueKey)
 			}
 			return nil, err
@@ -168,7 +173,7 @@ func (o *DefaultOrganizationProvider) membersExtended(ctx context.Context, role 
 	}
 
 	if etag, ok := o.cache.getEtag(etagKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.organization, "org-members-ext").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.githubName, o.organization, "org-members-ext").Inc()
 		o.cache.set(valueKey, etag, result)
 	}
 
@@ -209,7 +214,7 @@ func (o *DefaultOrganizationProvider) pendingAdminMembers(ctx context.Context) (
 				return result, nil
 			}
 			if resp != nil && resp.StatusCode == http.StatusNotModified {
-				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.organization, "org-invitations").Inc()
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.githubName, o.organization, "org-invitations").Inc()
 				if cached, ok := o.cache.getValue(firstPageKey); ok {
 					if v, ok := cached.([]GithubMember); ok {
 						return v, nil
@@ -244,7 +249,7 @@ func (o *DefaultOrganizationProvider) pendingAdminMembers(ctx context.Context) (
 	}
 
 	if etag, ok := o.cache.getEtag(firstPageKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.organization, "org-invitations").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.githubName, o.organization, "org-invitations").Inc()
 		o.cache.set(firstPageKey, etag, result)
 	}
 
@@ -266,7 +271,7 @@ func (o *DefaultOrganizationProvider) ExtendedMembers(ctx context.Context) ([]*g
 		users, resp, err := o.organizationService.ListMembers(ctx, o.organization, optMfa)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusNotModified {
-				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.organization, "org-members-2fa").Inc()
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.githubName, o.organization, "org-members-2fa").Inc()
 				if cached, ok := o.cache.getValue(mfaKey); ok {
 					if v, ok := cached.([]*gogithub.User); ok {
 						mfadisabled = v
@@ -285,7 +290,7 @@ func (o *DefaultOrganizationProvider) ExtendedMembers(ctx context.Context) ([]*g
 		optMfa.Page = resp.NextPage
 	}
 	if etag, ok := o.cache.getEtag(mfaKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.organization, "org-members-2fa").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.githubName, o.organization, "org-members-2fa").Inc()
 		o.cache.set(mfaKey, etag, mfadisabled)
 	}
 
@@ -298,7 +303,7 @@ func (o *DefaultOrganizationProvider) ExtendedMembers(ctx context.Context) ([]*g
 		users, resp, err := o.organizationService.ListMembers(ctx, o.organization, optAll)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusNotModified {
-				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.organization, "org-members-all").Inc()
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.githubName, o.organization, "org-members-all").Inc()
 				if cached, ok := o.cache.getValue(allKey); ok {
 					if v, ok := cached.([]*gogithub.User); ok {
 						allMembers = v
@@ -317,7 +322,7 @@ func (o *DefaultOrganizationProvider) ExtendedMembers(ctx context.Context) ([]*g
 		optAll.Page = resp.NextPage
 	}
 	if etag, ok := o.cache.getEtag(allKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.organization, "org-members-all").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.githubName, o.organization, "org-members-all").Inc()
 		o.cache.set(allKey, etag, allMembers)
 	}
 

--- a/internal/github/organizations.go
+++ b/internal/github/organizations.go
@@ -205,6 +205,7 @@ func (o *DefaultOrganizationProvider) pendingAdminMembers(ctx context.Context) (
 				return result, nil
 			}
 			if resp != nil && resp.StatusCode == http.StatusNotModified {
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(o.organization, "org-invitations").Inc()
 				if cached, ok := o.cache.getValue(firstPageKey); ok {
 					if v, ok := cached.([]GithubMember); ok {
 						return v, nil
@@ -239,6 +240,7 @@ func (o *DefaultOrganizationProvider) pendingAdminMembers(ctx context.Context) (
 	}
 
 	if etag, ok := o.cache.getEtag(firstPageKey); ok && etag != "" {
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(o.organization, "org-invitations").Inc()
 		o.cache.set(firstPageKey, etag, result)
 	}
 

--- a/internal/github/organizations.go
+++ b/internal/github/organizations.go
@@ -97,7 +97,8 @@ func (o *DefaultOrganizationProvider) members(ctx context.Context, role string) 
 						return v, nil
 					}
 				}
-				return []string{}, nil
+				o.cache.invalidate(firstPageKey)
+				return nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", firstPageKey)
 			}
 			return nil, err
 		}
@@ -145,7 +146,8 @@ func (o *DefaultOrganizationProvider) membersExtended(ctx context.Context, role 
 						return v, nil
 					}
 				}
-				return []GithubMember{}, nil
+				o.cache.invalidate(firstPageKey)
+				return nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", firstPageKey)
 			}
 			return nil, err
 		}
@@ -248,9 +250,11 @@ func (o *DefaultOrganizationProvider) ExtendedMembers(ctx context.Context) ([]*g
 				if cached, ok := o.cache.getValue(mfaKey); ok {
 					if v, ok := cached.([]*gogithub.User); ok {
 						mfadisabled = v
+						break
 					}
 				}
-				break
+				o.cache.invalidate(mfaKey)
+				return nil, nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", mfaKey)
 			}
 			return nil, nil, err
 		}
@@ -278,9 +282,11 @@ func (o *DefaultOrganizationProvider) ExtendedMembers(ctx context.Context) ([]*g
 				if cached, ok := o.cache.getValue(allKey); ok {
 					if v, ok := cached.([]*gogithub.User); ok {
 						allMembers = v
+						break
 					}
 				}
-				break
+				o.cache.invalidate(allKey)
+				return nil, nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", allKey)
 			}
 			return nil, nil, err
 		}

--- a/internal/github/organizations_test.go
+++ b/internal/github/organizations_test.go
@@ -34,6 +34,7 @@ func newTestOrganizationProvider(t *testing.T) (*DefaultOrganizationProvider, *h
 		organizationService: *client.Organizations,
 		usersService:        *client.Users,
 		organization:        "test-org",
+		cache:               &etagCache{entries: make(map[string]etagEntry)},
 	}
 	return provider, mux
 }

--- a/internal/github/repos.go
+++ b/internal/github/repos.go
@@ -202,12 +202,22 @@ type CollobaratorWithPermission struct {
 
 func (t *DefaultRepositoryProvider) RepositoryTeams(ctx context.Context, repo string) ([]repoguardsapv1.GithubTeamWithPermission, error) {
 
+	firstPageKey := fmt.Sprintf("/repos/%s/%s/teams?per_page=100", t.organization, repo)
 	opt := &github.ListOptions{PerPage: 100}
 
 	var allTeams []*github.Team
 	for {
 		teams, resp, err := t.repositoryService.ListTeams(ctx, t.organization, repo, opt)
 		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotModified {
+				if cached, ok := t.cache.getValue(firstPageKey); ok {
+					if v, ok := cached.([]repoguardsapv1.GithubTeamWithPermission); ok {
+						return v, nil
+					}
+				}
+				t.cache.invalidate(firstPageKey)
+				return nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", firstPageKey)
+			}
 			return nil, err
 		}
 		allTeams = append(allTeams, teams...)
@@ -231,6 +241,10 @@ func (t *DefaultRepositoryProvider) RepositoryTeams(ctx context.Context, repo st
 			perm = *t.Permission
 		}
 		teamWithPermissions = append(teamWithPermissions, repoguardsapv1.GithubTeamWithPermission{Team: slug, Permission: repoguardsapv1.GithubTeamPermission(perm)})
+	}
+
+	if etag, ok := t.cache.getEtag(firstPageKey); ok && etag != "" {
+		t.cache.set(firstPageKey, etag, teamWithPermissions)
 	}
 
 	return teamWithPermissions, nil

--- a/internal/github/repos.go
+++ b/internal/github/repos.go
@@ -210,6 +210,7 @@ func (t *DefaultRepositoryProvider) RepositoryTeams(ctx context.Context, repo st
 		teams, resp, err := t.repositoryService.ListTeams(ctx, t.organization, repo, opt)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusNotModified {
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.organization, "repo-teams").Inc()
 				if cached, ok := t.cache.getValue(firstPageKey); ok {
 					if v, ok := cached.([]repoguardsapv1.GithubTeamWithPermission); ok {
 						return v, nil
@@ -243,8 +244,11 @@ func (t *DefaultRepositoryProvider) RepositoryTeams(ctx context.Context, repo st
 		teamWithPermissions = append(teamWithPermissions, repoguardsapv1.GithubTeamWithPermission{Team: slug, Permission: repoguardsapv1.GithubTeamPermission(perm)})
 	}
 
-	if etag, ok := t.cache.getEtag(firstPageKey); ok && etag != "" {
-		t.cache.set(firstPageKey, etag, teamWithPermissions)
+	if t.cache != nil {
+		if etag, ok := t.cache.getEtag(firstPageKey); ok && etag != "" {
+			ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.organization, "repo-teams").Inc()
+			t.cache.set(firstPageKey, etag, teamWithPermissions)
+		}
 	}
 
 	return teamWithPermissions, nil

--- a/internal/github/repos.go
+++ b/internal/github/repos.go
@@ -33,12 +33,13 @@ type DefaultRepositoryProvider struct {
 	repositoryService github.RepositoriesService
 	teamsService      github.TeamsService
 	organization      string
+	githubName        string
 	graphqlClient     *githubv4.Client
 	cache             *etagCache
 }
 
 // installationID can be found at Organizations - Settings - Installed Github Apps and check the URL
-func NewRepositoryProvider(cc githubapp.ClientCreator, organization string, installationID int64) (RepositoryProvider, error) {
+func NewRepositoryProvider(cc githubapp.ClientCreator, githubName, organization string, installationID int64) (RepositoryProvider, error) {
 
 	client, err := cc.NewInstallationClient(installationID)
 	if err != nil {
@@ -56,7 +57,7 @@ func NewRepositoryProvider(cc githubapp.ClientCreator, organization string, inst
 		return nil, errors.New("organization name should not be empty")
 	}
 
-	cache := getOrCreateOrgCache(organization)
+	cache := getOrCreateOrgCache(githubName, organization)
 
 	// Build a cloned go-github client whose transport injects If-None-Match headers
 	// and captures ETag values from 200 responses for conditional GET caching.
@@ -85,6 +86,7 @@ func NewRepositoryProvider(cc githubapp.ClientCreator, organization string, inst
 		repositoryService: *etagClient.Repositories,
 		teamsService:      *client.Teams, // mutations don't benefit from ETag
 		organization:      organization,
+		githubName:        githubName,
 		graphqlClient:     gqlClient,
 		cache:             cache,
 	}, nil
@@ -210,7 +212,7 @@ func (t *DefaultRepositoryProvider) RepositoryTeams(ctx context.Context, repo st
 		teams, resp, err := t.repositoryService.ListTeams(ctx, t.organization, repo, opt)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusNotModified {
-				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.organization, "repo-teams").Inc()
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.githubName, t.organization, "repo-teams").Inc()
 				if cached, ok := t.cache.getValue(firstPageKey); ok {
 					if v, ok := cached.([]repoguardsapv1.GithubTeamWithPermission); ok {
 						return v, nil
@@ -246,7 +248,7 @@ func (t *DefaultRepositoryProvider) RepositoryTeams(ctx context.Context, repo st
 
 	if t.cache != nil {
 		if etag, ok := t.cache.getEtag(firstPageKey); ok && etag != "" {
-			ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.organization, "repo-teams").Inc()
+			ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.githubName, t.organization, "repo-teams").Inc()
 			t.cache.set(firstPageKey, etag, teamWithPermissions)
 		}
 	}
@@ -313,7 +315,7 @@ func (t *DefaultRepositoryProvider) RepositoryCollobarators(ctx context.Context,
 		users, resp, err := t.repositoryService.ListCollaborators(ctx, t.organization, repo, opt)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusNotModified {
-				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.organization, "repo-collaborators").Inc()
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.githubName, t.organization, "repo-collaborators").Inc()
 				if cached, ok := t.cache.getValue(firstPageKey); ok {
 					if v, ok := cached.([]string); ok {
 						return v, nil
@@ -346,7 +348,7 @@ func (t *DefaultRepositoryProvider) RepositoryCollobarators(ctx context.Context,
 
 	// Store the parsed result under the first-page URL key so a future 304 can return it.
 	if etag, ok := t.cache.getEtag(firstPageKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.organization, "repo-collaborators").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.githubName, t.organization, "repo-collaborators").Inc()
 		t.cache.set(firstPageKey, etag, collobarators)
 	}
 
@@ -360,7 +362,7 @@ func (t *DefaultRepositoryProvider) IsPrivate(ctx context.Context, repo string) 
 	r, response, err := t.repositoryService.Get(ctx, t.organization, repo)
 	if err != nil {
 		if response != nil && response.StatusCode == http.StatusNotModified {
-			ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.organization, "repo-visibility").Inc()
+			ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.githubName, t.organization, "repo-visibility").Inc()
 			if cached, ok := t.cache.getValue(repoKey); ok {
 				if v, ok := cached.(bool); ok {
 					return v, nil
@@ -379,7 +381,7 @@ func (t *DefaultRepositoryProvider) IsPrivate(ctx context.Context, repo string) 
 	isPrivate := vis == "private" || vis == "internal"
 
 	if etag, ok := t.cache.getEtag(repoKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.organization, "repo-visibility").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.githubName, t.organization, "repo-visibility").Inc()
 		t.cache.set(repoKey, etag, isPrivate)
 	}
 

--- a/internal/github/repos.go
+++ b/internal/github/repos.go
@@ -301,7 +301,8 @@ func (t *DefaultRepositoryProvider) RepositoryCollobarators(ctx context.Context,
 						return v, nil
 					}
 				}
-				return []string{}, nil
+				t.cache.invalidate(firstPageKey)
+				return nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", firstPageKey)
 			}
 			return nil, err
 		}
@@ -347,7 +348,8 @@ func (t *DefaultRepositoryProvider) IsPrivate(ctx context.Context, repo string) 
 					return v, nil
 				}
 			}
-			return false, nil
+			t.cache.invalidate(repoKey)
+			return false, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", repoKey)
 		}
 		return false, err
 	}

--- a/internal/github/repos.go
+++ b/internal/github/repos.go
@@ -7,16 +7,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
+	"github.com/google/go-github/v88/github"
 	"github.com/palantir/go-githubapp/githubapp"
+	githubv4 "github.com/shurcooL/githubv4"
 
 	repoguardsapv1 "github.com/cloudoperators/repo-guard/api/v1"
-	"github.com/google/go-github/v88/github"
+	ghmetrics "github.com/cloudoperators/repo-guard/internal/metrics"
 )
 
 type RepositoryProvider interface {
 	List(ctx context.Context) ([]string, []string, []string, error)
 	ExtendedList(ctx context.Context) ([]repoguardsapv1.GithubRepository, []repoguardsapv1.GithubRepository, []repoguardsapv1.GithubRepository, error)
+	ExtendedListGraphQL(ctx context.Context) ([]repoguardsapv1.GithubRepository, []repoguardsapv1.GithubRepository, []repoguardsapv1.GithubRepository, error)
 	RepositoryTeams(ctx context.Context, repo string) ([]repoguardsapv1.GithubTeamWithPermission, error)
 	RepositoryTeamAdd(ctx context.Context, repo, team string, permission repoguardsapv1.GithubTeamPermission) error
 	RepositoryTeamRemove(ctx context.Context, repo, team string) error
@@ -29,6 +33,8 @@ type DefaultRepositoryProvider struct {
 	repositoryService github.RepositoriesService
 	teamsService      github.TeamsService
 	organization      string
+	graphqlClient     *githubv4.Client
+	cache             *etagCache
 }
 
 // installationID can be found at Organizations - Settings - Installed Github Apps and check the URL
@@ -49,7 +55,39 @@ func NewRepositoryProvider(cc githubapp.ClientCreator, organization string, inst
 	if organization == "" {
 		return nil, errors.New("organization name should not be empty")
 	}
-	return &DefaultRepositoryProvider{repositoryService: *client.Repositories, teamsService: *client.Teams, organization: organization}, nil
+
+	cache := getOrCreateOrgCache(organization)
+
+	// Build a cloned go-github client whose transport injects If-None-Match headers
+	// and captures ETag values from 200 responses for conditional GET caching.
+	baseHTTP := client.Client()
+	baseTransport := baseHTTP.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	etagHTTP := &http.Client{
+		Transport:     &etagTransport{wrapped: baseTransport, cache: cache, keyFn: urlCacheKey},
+		CheckRedirect: baseHTTP.CheckRedirect,
+		Jar:           baseHTTP.Jar,
+		Timeout:       baseHTTP.Timeout,
+	}
+	etagClient, err := client.Clone(github.WithHTTPClient(etagHTTP))
+	if err != nil {
+		return nil, fmt.Errorf("clone github client with etag transport: %w", err)
+	}
+
+	gqlClient, err := cc.NewInstallationV4Client(installationID)
+	if err != nil {
+		return nil, fmt.Errorf("create installation v4 client: %w", err)
+	}
+
+	return &DefaultRepositoryProvider{
+		repositoryService: *etagClient.Repositories,
+		teamsService:      *client.Teams, // mutations don't benefit from ETag
+		organization:      organization,
+		graphqlClient:     gqlClient,
+		cache:             cache,
+	}, nil
 }
 
 func (t *DefaultRepositoryProvider) ExtendedList(ctx context.Context) ([]repoguardsapv1.GithubRepository, []repoguardsapv1.GithubRepository, []repoguardsapv1.GithubRepository, error) {
@@ -243,6 +281,11 @@ func (t *DefaultRepositoryProvider) RepositoryTeamRemove(ctx context.Context, re
 
 func (t *DefaultRepositoryProvider) RepositoryCollobarators(ctx context.Context, repo string) ([]string, error) {
 
+	// The ETag transport (injected at construction via NewRepositoryProvider) automatically
+	// injects If-None-Match on GETs and stores new ETags from 200 responses.
+	// On 304, go-github returns a non-nil *ErrorResponse; we retrieve the cached value.
+	firstPageKey := fmt.Sprintf("/repos/%s/%s/collaborators?per_page=100", t.organization, repo)
+
 	opt := &github.ListCollaboratorsOptions{
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
@@ -251,6 +294,15 @@ func (t *DefaultRepositoryProvider) RepositoryCollobarators(ctx context.Context,
 	for {
 		users, resp, err := t.repositoryService.ListCollaborators(ctx, t.organization, repo, opt)
 		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotModified {
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.organization, "repo-collaborators").Inc()
+				if cached, ok := t.cache.getValue(firstPageKey); ok {
+					if v, ok := cached.([]string); ok {
+						return v, nil
+					}
+				}
+				return []string{}, nil
+			}
 			return nil, err
 		}
 		allUsers = append(allUsers, users...)
@@ -273,14 +325,30 @@ func (t *DefaultRepositoryProvider) RepositoryCollobarators(ctx context.Context,
 		collobarators = append(collobarators, login)
 	}
 
+	// Store the parsed result under the first-page URL key so a future 304 can return it.
+	if etag, ok := t.cache.getEtag(firstPageKey); ok && etag != "" {
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.organization, "repo-collaborators").Inc()
+		t.cache.set(firstPageKey, etag, collobarators)
+	}
+
 	return collobarators, nil
 }
 
 func (t *DefaultRepositoryProvider) IsPrivate(ctx context.Context, repo string) (bool, error) {
 
-	r, response, err := t.repositoryService.Get(ctx, t.organization, repo)
+	repoKey := fmt.Sprintf("/repos/%s/%s", t.organization, repo)
 
+	r, response, err := t.repositoryService.Get(ctx, t.organization, repo)
 	if err != nil {
+		if response != nil && response.StatusCode == http.StatusNotModified {
+			ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.organization, "repo-visibility").Inc()
+			if cached, ok := t.cache.getValue(repoKey); ok {
+				if v, ok := cached.(bool); ok {
+					return v, nil
+				}
+			}
+			return false, nil
+		}
 		return false, err
 	}
 	if response.StatusCode != 200 {
@@ -288,9 +356,12 @@ func (t *DefaultRepositoryProvider) IsPrivate(ctx context.Context, repo string) 
 	}
 
 	vis := r.GetVisibility()
-	if vis == "private" || vis == "internal" {
-		return true, nil
+	isPrivate := vis == "private" || vis == "internal"
+
+	if etag, ok := t.cache.getEtag(repoKey); ok && etag != "" {
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.organization, "repo-visibility").Inc()
+		t.cache.set(repoKey, etag, isPrivate)
 	}
 
-	return false, nil
+	return isPrivate, nil
 }

--- a/internal/github/repos_graphql.go
+++ b/internal/github/repos_graphql.go
@@ -86,10 +86,10 @@ func (t *DefaultRepositoryProvider) ExtendedListGraphQL(ctx context.Context) ([]
 		}
 
 		if err := t.graphqlClient.Query(ctx, &query, vars); err != nil {
-			ghmetrics.GraphQLCallsTotal.WithLabelValues(t.organization, "error").Inc()
+			ghmetrics.GraphQLCallsTotal.WithLabelValues(t.githubName, t.organization, "error").Inc()
 			return nil, nil, nil, err
 		}
-		ghmetrics.GraphQLCallsTotal.WithLabelValues(t.organization, "success").Inc()
+		ghmetrics.GraphQLCallsTotal.WithLabelValues(t.githubName, t.organization, "success").Inc()
 
 		for _, node := range query.Organization.Repositories.Nodes {
 			if bool(node.IsArchived) || bool(node.IsDisabled) {

--- a/internal/github/repos_graphql.go
+++ b/internal/github/repos_graphql.go
@@ -6,7 +6,6 @@ package github
 import (
 	"context"
 	"strings"
-	"time"
 
 	githubv4 "github.com/shurcooL/githubv4"
 
@@ -86,13 +85,11 @@ func (t *DefaultRepositoryProvider) ExtendedListGraphQL(ctx context.Context) ([]
 			"teamCursor": (*githubv4.String)(nil),
 		}
 
-		started := time.Now()
 		if err := t.graphqlClient.Query(ctx, &query, vars); err != nil {
 			ghmetrics.GraphQLCallsTotal.WithLabelValues(t.organization, "error").Inc()
 			return nil, nil, nil, err
 		}
 		ghmetrics.GraphQLCallsTotal.WithLabelValues(t.organization, "success").Inc()
-		_ = started // duration tracking can be added later via ghmetrics.ObserveExternalRequest
 
 		for _, node := range query.Organization.Repositories.Nodes {
 			if bool(node.IsArchived) || bool(node.IsDisabled) {

--- a/internal/github/repos_graphql.go
+++ b/internal/github/repos_graphql.go
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	githubv4 "github.com/shurcooL/githubv4"
+
+	repoguardsapv1 "github.com/cloudoperators/repo-guard/api/v1"
+	ghmetrics "github.com/cloudoperators/repo-guard/internal/metrics"
+)
+
+// orgReposWithTeamsQuery is the GraphQL query struct for fetching all organisation
+// repositories and their associated team permissions in a single paginated request.
+type orgReposWithTeamsQuery struct {
+	Organization struct {
+		Repositories struct {
+			PageInfo struct {
+				HasNextPage githubv4.Boolean
+				EndCursor   githubv4.String
+			}
+			Nodes []struct {
+				Name       githubv4.String
+				Visibility githubv4.String
+				IsArchived githubv4.Boolean
+				IsDisabled githubv4.Boolean
+				Teams      struct {
+					PageInfo struct {
+						HasNextPage githubv4.Boolean
+						EndCursor   githubv4.String
+					}
+					Edges []struct {
+						Permission githubv4.String
+						Node       struct{ Slug githubv4.String }
+					}
+				} `graphql:"teams(first: 100, after: $teamCursor)"`
+			}
+		} `graphql:"repositories(first: 100, after: $repoCursor, orderBy: {field: NAME, direction: ASC})"`
+	} `graphql:"organization(login: $org)"`
+}
+
+// graphqlPermissionToTeamPermission converts a GraphQL RepositoryPermission enum
+// value to the internal GithubTeamPermission type.
+// GitHub GraphQL uses: ADMIN, MAINTAIN, WRITE, TRIAGE, READ.
+// The REST API and our internal type use: admin, maintain, push, triage, pull.
+func graphqlPermissionToTeamPermission(p string) repoguardsapv1.GithubTeamPermission {
+	switch strings.ToUpper(p) {
+	case "ADMIN":
+		return "admin"
+	case "MAINTAIN":
+		return "maintain"
+	case "WRITE":
+		return "push" // GraphQL WRITE maps to REST push
+	case "TRIAGE":
+		return "triage"
+	case "READ":
+		return "pull"
+	default:
+		return repoguardsapv1.GithubTeamPermission(strings.ToLower(p))
+	}
+}
+
+// ExtendedListGraphQL fetches all organisation repositories and their team permissions
+// using a single paginated GraphQL query instead of N+1 REST calls.
+// For 300 repositories this reduces ~303 REST calls to 3–4 GraphQL calls per reconcile.
+//
+// Repos that are archived or disabled are excluded (same semantics as List/ExtendedList).
+// If a repository has more than 100 teams (extremely rare), the method falls back to a
+// REST call for that specific repository only.
+func (t *DefaultRepositoryProvider) ExtendedListGraphQL(ctx context.Context) ([]repoguardsapv1.GithubRepository, []repoguardsapv1.GithubRepository, []repoguardsapv1.GithubRepository, error) {
+	publicRepos := make([]repoguardsapv1.GithubRepository, 0)
+	privateRepos := make([]repoguardsapv1.GithubRepository, 0)
+	internalRepos := make([]repoguardsapv1.GithubRepository, 0)
+
+	var repoCursor *githubv4.String // nil = first page
+
+	for {
+		var query orgReposWithTeamsQuery
+		vars := map[string]any{
+			"org":        githubv4.String(t.organization),
+			"repoCursor": repoCursor,
+			"teamCursor": (*githubv4.String)(nil),
+		}
+
+		started := time.Now()
+		if err := t.graphqlClient.Query(ctx, &query, vars); err != nil {
+			ghmetrics.GraphQLCallsTotal.WithLabelValues(t.organization, "error").Inc()
+			return nil, nil, nil, err
+		}
+		ghmetrics.GraphQLCallsTotal.WithLabelValues(t.organization, "success").Inc()
+		_ = started // duration tracking can be added later via ghmetrics.ObserveExternalRequest
+
+		for _, node := range query.Organization.Repositories.Nodes {
+			if bool(node.IsArchived) || bool(node.IsDisabled) {
+				continue
+			}
+			name := string(node.Name)
+			if name == "" {
+				continue
+			}
+
+			var teams []repoguardsapv1.GithubTeamWithPermission
+			if bool(node.Teams.PageInfo.HasNextPage) {
+				// Rare edge case: repo has >100 teams. Fall back to REST for this repo.
+				var err error
+				teams, err = t.RepositoryTeams(ctx, name)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+			} else {
+				teams = make([]repoguardsapv1.GithubTeamWithPermission, 0, len(node.Teams.Edges))
+				for _, edge := range node.Teams.Edges {
+					slug := string(edge.Node.Slug)
+					if slug == "" {
+						continue
+					}
+					perm := graphqlPermissionToTeamPermission(string(edge.Permission))
+					teams = append(teams, repoguardsapv1.GithubTeamWithPermission{
+						Team:       slug,
+						Permission: perm,
+					})
+				}
+			}
+
+			repo := repoguardsapv1.GithubRepository{Name: name, Teams: teams}
+			switch strings.ToLower(string(node.Visibility)) {
+			case "public":
+				publicRepos = append(publicRepos, repo)
+			case "private":
+				privateRepos = append(privateRepos, repo)
+			case "internal":
+				internalRepos = append(internalRepos, repo)
+			default:
+				// Skip repos with unknown visibility (same policy as List()).
+			}
+		}
+
+		if !bool(query.Organization.Repositories.PageInfo.HasNextPage) {
+			break
+		}
+		cursor := query.Organization.Repositories.PageInfo.EndCursor
+		repoCursor = &cursor
+	}
+
+	return publicRepos, privateRepos, internalRepos, nil
+}

--- a/internal/github/repos_graphql_test.go
+++ b/internal/github/repos_graphql_test.go
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gogithub "github.com/google/go-github/v88/github"
+	githubv4 "github.com/shurcooL/githubv4"
+
+	repoguardsapv1 "github.com/cloudoperators/repo-guard/api/v1"
+)
+
+// graphqlResponse is the top-level structure returned by the mock GraphQL server.
+type graphqlResponse struct {
+	Data any `json:"data"`
+}
+
+// newTestRepositoryProviderWithGraphQL creates a DefaultRepositoryProvider backed
+// by a fake HTTP server that serves both REST (under /api/v3/) and GraphQL (at /).
+// The caller registers handlers on the returned mux.
+func newTestRepositoryProviderWithGraphQL(t *testing.T, graphqlHandler http.HandlerFunc) *DefaultRepositoryProvider {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	// REST client (go-github) hits /api/v3/
+	restClient, err := gogithub.NewClient(
+		gogithub.WithHTTPClient(srv.Client()),
+		gogithub.WithAuthToken("test-token"),
+		gogithub.WithEnterpriseURLs(srv.URL+"/api/v3/", srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("create github client: %v", err)
+	}
+
+	// GraphQL client (shurcooL/githubv4) posts to / (the root path of the server).
+	gqlClient := githubv4.NewEnterpriseClient(srv.URL+"/", srv.Client())
+
+	if graphqlHandler != nil {
+		mux.HandleFunc("/", graphqlHandler)
+	}
+
+	return &DefaultRepositoryProvider{
+		repositoryService: *restClient.Repositories,
+		teamsService:      *restClient.Teams,
+		organization:      "test-org",
+		graphqlClient:     gqlClient,
+	}
+}
+
+// buildOrgReposGraphQLResponse builds the JSON response body for a single-page
+// GraphQL query returning the given repos.
+func buildOrgReposGraphQLResponse(nodes []map[string]any, hasNextPage bool, endCursor string) string {
+	data := map[string]any{
+		"organization": map[string]any{
+			"repositories": map[string]any{
+				"pageInfo": map[string]any{
+					"hasNextPage": hasNextPage,
+					"endCursor":   endCursor,
+				},
+				"nodes": nodes,
+			},
+		},
+	}
+	b, _ := json.Marshal(graphqlResponse{Data: data})
+	return string(b)
+}
+
+// buildRepoNode builds a single repository node for a GraphQL fixture.
+func buildRepoNode(name, visibility string, archived, disabled bool, teams []map[string]any, teamsHasNextPage bool) map[string]any {
+	return map[string]any{
+		"name":       name,
+		"visibility": visibility,
+		"isArchived": archived,
+		"isDisabled": disabled,
+		"teams": map[string]any{
+			"pageInfo": map[string]any{
+				"hasNextPage": teamsHasNextPage,
+				"endCursor":   "",
+			},
+			"edges": teams,
+		},
+	}
+}
+
+// buildTeamEdge builds a single team edge (permission + slug) for a GraphQL fixture.
+func buildTeamEdge(slug, permission string) map[string]any {
+	return map[string]any{
+		"permission": permission,
+		"node":       map[string]any{"slug": slug},
+	}
+}
+
+func TestGraphqlPermissionToTeamPermission(t *testing.T) {
+	cases := []struct {
+		input string
+		want  repoguardsapv1.GithubTeamPermission
+	}{
+		{"ADMIN", "admin"},
+		{"MAINTAIN", "maintain"},
+		{"WRITE", "push"}, // critical mapping
+		{"TRIAGE", "triage"},
+		{"READ", "pull"},
+		{"write", "push"},      // lowercase
+		{"admin", "admin"},     // lowercase passthrough via default
+		{"UNKNOWN", "unknown"}, // unknown values lower-cased
+	}
+	for _, tc := range cases {
+		got := graphqlPermissionToTeamPermission(tc.input)
+		if got != tc.want {
+			t.Errorf("graphqlPermissionToTeamPermission(%q): got %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestExtendedListGraphQL_Basic(t *testing.T) {
+	// One page, three repos across all visibility buckets.
+	nodes := []map[string]any{
+		buildRepoNode("pub-repo", "PUBLIC", false, false, []map[string]any{
+			buildTeamEdge("devs", "WRITE"),
+		}, false),
+		buildRepoNode("priv-repo", "PRIVATE", false, false, []map[string]any{
+			buildTeamEdge("ops", "ADMIN"),
+		}, false),
+		buildRepoNode("int-repo", "INTERNAL", false, false, []map[string]any{
+			buildTeamEdge("security", "READ"),
+		}, false),
+	}
+	respBody := buildOrgReposGraphQLResponse(nodes, false, "")
+
+	provider := newTestRepositoryProviderWithGraphQL(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(respBody)) //nolint:errcheck
+	})
+
+	pub, priv, internal, err := provider.ExtendedListGraphQL(t.Context())
+	if err != nil {
+		t.Fatalf("ExtendedListGraphQL: unexpected error: %v", err)
+	}
+
+	if len(pub) != 1 || pub[0].Name != "pub-repo" {
+		t.Errorf("public repos: got %v", pub)
+	}
+	if len(priv) != 1 || priv[0].Name != "priv-repo" {
+		t.Errorf("private repos: got %v", priv)
+	}
+	if len(internal) != 1 || internal[0].Name != "int-repo" {
+		t.Errorf("internal repos: got %v", internal)
+	}
+
+	// Verify permission mapping: WRITE → push
+	if len(pub[0].Teams) != 1 || pub[0].Teams[0].Permission != "push" {
+		t.Errorf("pub-repo teams: got %v, want push permission", pub[0].Teams)
+	}
+	if len(priv[0].Teams) != 1 || priv[0].Teams[0].Permission != "admin" {
+		t.Errorf("priv-repo teams: got %v, want admin permission", priv[0].Teams)
+	}
+	if len(internal[0].Teams) != 1 || internal[0].Teams[0].Permission != "pull" {
+		t.Errorf("int-repo teams: got %v, want pull permission", internal[0].Teams)
+	}
+}
+
+func TestExtendedListGraphQL_Pagination(t *testing.T) {
+	// Two pages: first returns has_next_page=true, second returns false.
+	page1Nodes := []map[string]any{
+		buildRepoNode("repo-a", "PUBLIC", false, false, nil, false),
+	}
+	page2Nodes := []map[string]any{
+		buildRepoNode("repo-b", "PRIVATE", false, false, nil, false),
+	}
+
+	callCount := 0
+	provider := newTestRepositoryProviderWithGraphQL(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		callCount++
+		var body string
+		if callCount == 1 {
+			body = buildOrgReposGraphQLResponse(page1Nodes, true, "cursor-abc")
+		} else {
+			body = buildOrgReposGraphQLResponse(page2Nodes, false, "")
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(body)) //nolint:errcheck
+	})
+
+	pub, priv, _, err := provider.ExtendedListGraphQL(t.Context())
+	if err != nil {
+		t.Fatalf("ExtendedListGraphQL: unexpected error: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 GraphQL calls, got %d", callCount)
+	}
+	if len(pub) != 1 || pub[0].Name != "repo-a" {
+		t.Errorf("public repos: got %v", pub)
+	}
+	if len(priv) != 1 || priv[0].Name != "repo-b" {
+		t.Errorf("private repos: got %v", priv)
+	}
+}
+
+func TestExtendedListGraphQL_ArchivedFiltered(t *testing.T) {
+	// Archived and disabled repos must be excluded.
+	nodes := []map[string]any{
+		buildRepoNode("active-repo", "PUBLIC", false, false, nil, false),
+		buildRepoNode("archived-repo", "PUBLIC", true, false, nil, false),
+		buildRepoNode("disabled-repo", "PRIVATE", false, true, nil, false),
+	}
+	respBody := buildOrgReposGraphQLResponse(nodes, false, "")
+
+	provider := newTestRepositoryProviderWithGraphQL(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(respBody)) //nolint:errcheck
+	})
+
+	pub, priv, _, err := provider.ExtendedListGraphQL(t.Context())
+	if err != nil {
+		t.Fatalf("ExtendedListGraphQL: unexpected error: %v", err)
+	}
+	if len(pub) != 1 || pub[0].Name != "active-repo" {
+		t.Errorf("expected only active-repo in public, got %v", pub)
+	}
+	if len(priv) != 0 {
+		t.Errorf("expected no private repos, got %v", priv)
+	}
+}
+
+func TestExtendedListGraphQL_TeamOverflow(t *testing.T) {
+	// A repo with teamsHasNextPage=true must fall back to the REST RepositoryTeams endpoint.
+	nodes := []map[string]any{
+		buildRepoNode("overflow-repo", "PRIVATE", false, false, []map[string]any{
+			buildTeamEdge("team-gql", "READ"),
+		}, true), // HasNextPage=true triggers REST fallback
+	}
+	respBody := buildOrgReposGraphQLResponse(nodes, false, "")
+
+	restTeamsFixture := []map[string]any{
+		{"id": 1, "slug": "team-rest", "name": "team-rest", "permission": "push"},
+	}
+
+	callCount := 0
+	provider := newTestRepositoryProviderWithGraphQL(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(respBody)) //nolint:errcheck
+	})
+
+	// Register the REST fallback handler for RepositoryTeams.
+	// We reconstruct the mux by creating a separate provider using the existing REST approach.
+	// Since newTestRepositoryProviderWithGraphQL routes / to the graphqlHandler,
+	// we need to also register REST handlers on the same mux.
+	// Instead, create a separate REST server for the fallback.
+	restMux := http.NewServeMux()
+	restSrv := httptest.NewServer(restMux)
+	t.Cleanup(restSrv.Close)
+
+	restMux.HandleFunc("/api/v3/repos/test-org/overflow-repo/teams", func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(restTeamsFixture) //nolint:errcheck
+	})
+
+	restClient, err := gogithub.NewClient(
+		gogithub.WithHTTPClient(restSrv.Client()),
+		gogithub.WithAuthToken("test-token"),
+		gogithub.WithEnterpriseURLs(restSrv.URL+"/api/v3/", restSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("create rest client: %v", err)
+	}
+	// Override the REST services on the provider.
+	provider.repositoryService = *restClient.Repositories
+	provider.teamsService = *restClient.Teams
+
+	_, priv, _, err := provider.ExtendedListGraphQL(t.Context())
+	if err != nil {
+		t.Fatalf("ExtendedListGraphQL: unexpected error: %v", err)
+	}
+
+	if callCount != 1 {
+		t.Errorf("expected 1 REST fallback call, got %d", callCount)
+	}
+	if len(priv) != 1 {
+		t.Fatalf("expected 1 private repo, got %v", priv)
+	}
+	// Teams should come from REST fallback, not GraphQL partial result.
+	if len(priv[0].Teams) != 1 || priv[0].Teams[0].Team != "team-rest" {
+		t.Errorf("expected REST-sourced team, got %v", priv[0].Teams)
+	}
+}

--- a/internal/github/repos_test.go
+++ b/internal/github/repos_test.go
@@ -34,6 +34,7 @@ func newTestRepositoryProvider(t *testing.T) (*DefaultRepositoryProvider, *http.
 		repositoryService: *client.Repositories,
 		teamsService:      *client.Teams,
 		organization:      "test-org",
+		cache:             &etagCache{entries: make(map[string]etagEntry)},
 	}
 	return provider, mux
 }

--- a/internal/github/teams.go
+++ b/internal/github/teams.go
@@ -92,7 +92,8 @@ func (t *DefaultTeamsProvider) List(ctx context.Context) ([]string, error) {
 						return v, nil
 					}
 				}
-				return []string{}, nil
+				t.cache.invalidate(firstPageKey)
+				return nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", firstPageKey)
 			}
 			return nil, err
 		}
@@ -145,7 +146,8 @@ func (t DefaultTeamsProvider) MembersExtended(ctx context.Context, team string) 
 						return v, nil
 					}
 				}
-				return []GithubMember{}, nil
+				t.cache.invalidate(firstPageKey)
+				return nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", firstPageKey)
 			}
 			return nil, err
 		}
@@ -189,7 +191,8 @@ func (t DefaultTeamsProvider) Members(ctx context.Context, team string) ([]strin
 						return v, nil
 					}
 				}
-				return []string{}, nil
+				t.cache.invalidate(firstPageKey)
+				return nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", firstPageKey)
 			}
 			return nil, err
 		}

--- a/internal/github/teams.go
+++ b/internal/github/teams.go
@@ -34,11 +34,12 @@ type GithubMember struct {
 type DefaultTeamsProvider struct {
 	service      gogithub.TeamsService
 	organization string
+	githubName   string
 	cache        *etagCache
 }
 
 // installationID can be found at Organizations - Settings - Installed Github Apps and check the URL
-func NewTeamsProvider(cc githubapp.ClientCreator, organization string, installationID int64) (TeamsProvider, error) {
+func NewTeamsProvider(cc githubapp.ClientCreator, githubName, organization string, installationID int64) (TeamsProvider, error) {
 
 	client, err := cc.NewInstallationClient(installationID)
 	if err != nil {
@@ -51,7 +52,7 @@ func NewTeamsProvider(cc githubapp.ClientCreator, organization string, installat
 		return nil, errors.New("organization name should not be empty")
 	}
 
-	cache := getOrCreateOrgCache(organization)
+	cache := getOrCreateOrgCache(githubName, organization)
 
 	// Clone the client with an ETag transport for conditional GET caching.
 	baseHTTP := client.Client()
@@ -70,7 +71,7 @@ func NewTeamsProvider(cc githubapp.ClientCreator, organization string, installat
 		return nil, fmt.Errorf("clone github client with etag transport: %w", err)
 	}
 
-	return &DefaultTeamsProvider{service: *etagClient.Teams, organization: organization, cache: cache}, nil
+	return &DefaultTeamsProvider{service: *etagClient.Teams, organization: organization, githubName: githubName, cache: cache}, nil
 }
 
 func (t *DefaultTeamsProvider) List(ctx context.Context) ([]string, error) {
@@ -86,7 +87,7 @@ func (t *DefaultTeamsProvider) List(ctx context.Context) ([]string, error) {
 		teams, response, err := t.service.ListTeams(ctx, t.organization, opt)
 		if err != nil {
 			if response != nil && response.StatusCode == http.StatusNotModified {
-				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.organization, "teams-list").Inc()
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.githubName, t.organization, "teams-list").Inc()
 				if cached, ok := t.cache.getValue(firstPageKey); ok {
 					if v, ok := cached.([]string); ok {
 						return v, nil
@@ -119,7 +120,7 @@ func (t *DefaultTeamsProvider) List(ctx context.Context) ([]string, error) {
 	}
 
 	if etag, ok := t.cache.getEtag(firstPageKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.organization, "teams-list").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.githubName, t.organization, "teams-list").Inc()
 		t.cache.set(firstPageKey, etag, teamList)
 	}
 
@@ -144,13 +145,16 @@ func (t DefaultTeamsProvider) MembersExtended(ctx context.Context, team string) 
 		users, resp, err := t.service.ListTeamMembersBySlug(ctx, t.organization, teamSlug, opt)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusNotModified {
-				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.organization, "team-members-ext").Inc()
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.githubName, t.organization, "team-members-ext").Inc()
 				if cached, ok := t.cache.getValue(valueKey); ok {
 					if v, ok := cached.([]GithubMember); ok {
 						return v, nil
 					}
 				}
+				// Invalidate both the value key and the ETag key so the transport
+				// stops injecting If-None-Match and forces a fresh 200 on the next call.
 				t.cache.invalidate(valueKey)
+				t.cache.invalidate(etagKey)
 				return nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", valueKey)
 			}
 			return nil, err
@@ -168,7 +172,7 @@ func (t DefaultTeamsProvider) MembersExtended(ctx context.Context, team string) 
 	}
 
 	if etag, ok := t.cache.getEtag(etagKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.organization, "team-members-ext").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.githubName, t.organization, "team-members-ext").Inc()
 		t.cache.set(valueKey, etag, userList)
 	}
 
@@ -189,7 +193,7 @@ func (t DefaultTeamsProvider) Members(ctx context.Context, team string) ([]strin
 		users, resp, err := t.service.ListTeamMembersBySlug(ctx, t.organization, teamSlug, opt)
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusNotModified {
-				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.organization, "team-members").Inc()
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.githubName, t.organization, "team-members").Inc()
 				if cached, ok := t.cache.getValue(firstPageKey); ok {
 					if v, ok := cached.([]string); ok {
 						return v, nil
@@ -217,7 +221,7 @@ func (t DefaultTeamsProvider) Members(ctx context.Context, team string) ([]strin
 	}
 
 	if etag, ok := t.cache.getEtag(firstPageKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.organization, "team-members").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.githubName, t.organization, "team-members").Inc()
 		t.cache.set(firstPageKey, etag, userList)
 	}
 

--- a/internal/github/teams.go
+++ b/internal/github/teams.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
+	gogithub "github.com/google/go-github/v88/github"
+	"github.com/gosimple/slug"
 	"github.com/palantir/go-githubapp/githubapp"
 
-	"github.com/gosimple/slug"
-
-	"github.com/google/go-github/v88/github"
+	ghmetrics "github.com/cloudoperators/repo-guard/internal/metrics"
 )
 
 type TeamsProvider interface {
@@ -31,8 +32,9 @@ type GithubMember struct {
 }
 
 type DefaultTeamsProvider struct {
-	service      github.TeamsService
+	service      gogithub.TeamsService
 	organization string
+	cache        *etagCache
 }
 
 // installationID can be found at Organizations - Settings - Installed Github Apps and check the URL
@@ -49,12 +51,33 @@ func NewTeamsProvider(cc githubapp.ClientCreator, organization string, installat
 		return nil, errors.New("organization name should not be empty")
 	}
 
-	return &DefaultTeamsProvider{service: *client.Teams, organization: organization}, nil
+	cache := getOrCreateOrgCache(organization)
+
+	// Clone the client with an ETag transport for conditional GET caching.
+	baseHTTP := client.Client()
+	baseTransport := baseHTTP.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	etagHTTP := &http.Client{
+		Transport:     &etagTransport{wrapped: baseTransport, cache: cache, keyFn: urlCacheKey},
+		CheckRedirect: baseHTTP.CheckRedirect,
+		Jar:           baseHTTP.Jar,
+		Timeout:       baseHTTP.Timeout,
+	}
+	etagClient, err := client.Clone(gogithub.WithHTTPClient(etagHTTP))
+	if err != nil {
+		return nil, fmt.Errorf("clone github client with etag transport: %w", err)
+	}
+
+	return &DefaultTeamsProvider{service: *etagClient.Teams, organization: organization, cache: cache}, nil
 }
 
 func (t *DefaultTeamsProvider) List(ctx context.Context) ([]string, error) {
 
-	opt := &github.ListOptions{
+	firstPageKey := fmt.Sprintf("/orgs/%s/teams?per_page=100", t.organization)
+
+	opt := &gogithub.ListOptions{
 		PerPage: 100,
 	}
 
@@ -62,6 +85,15 @@ func (t *DefaultTeamsProvider) List(ctx context.Context) ([]string, error) {
 	for {
 		teams, response, err := t.service.ListTeams(ctx, t.organization, opt)
 		if err != nil {
+			if response != nil && response.StatusCode == http.StatusNotModified {
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.organization, "teams-list").Inc()
+				if cached, ok := t.cache.getValue(firstPageKey); ok {
+					if v, ok := cached.([]string); ok {
+						return v, nil
+					}
+				}
+				return []string{}, nil
+			}
 			return nil, err
 		}
 		for _, team := range teams {
@@ -85,20 +117,36 @@ func (t *DefaultTeamsProvider) List(ctx context.Context) ([]string, error) {
 		opt.Page = response.NextPage
 	}
 
-	return teamList, nil
+	if etag, ok := t.cache.getEtag(firstPageKey); ok && etag != "" {
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.organization, "teams-list").Inc()
+		t.cache.set(firstPageKey, etag, teamList)
+	}
 
+	return teamList, nil
 }
 
 func (t DefaultTeamsProvider) MembersExtended(ctx context.Context, team string) ([]GithubMember, error) {
 
-	opt := &github.TeamListTeamMembersOptions{
-		ListOptions: github.ListOptions{PerPage: 100},
+	teamSlug := slug.Make(team)
+	firstPageKey := fmt.Sprintf("/orgs/%s/teams/%s/members?per_page=100", t.organization, teamSlug)
+
+	opt := &gogithub.TeamListTeamMembersOptions{
+		ListOptions: gogithub.ListOptions{PerPage: 100},
 	}
 
 	userList := make([]GithubMember, 0)
 	for {
-		users, resp, err := t.service.ListTeamMembersBySlug(ctx, t.organization, slug.Make(team), opt)
+		users, resp, err := t.service.ListTeamMembersBySlug(ctx, t.organization, teamSlug, opt)
 		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotModified {
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.organization, "team-members-ext").Inc()
+				if cached, ok := t.cache.getValue(firstPageKey); ok {
+					if v, ok := cached.([]GithubMember); ok {
+						return v, nil
+					}
+				}
+				return []GithubMember{}, nil
+			}
 			return nil, err
 		}
 		for _, user := range users {
@@ -113,19 +161,36 @@ func (t DefaultTeamsProvider) MembersExtended(ctx context.Context, team string) 
 		opt.Page = resp.NextPage
 	}
 
+	if etag, ok := t.cache.getEtag(firstPageKey); ok && etag != "" {
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.organization, "team-members-ext").Inc()
+		t.cache.set(firstPageKey, etag, userList)
+	}
+
 	return userList, nil
 }
 
 func (t DefaultTeamsProvider) Members(ctx context.Context, team string) ([]string, error) {
 
-	opt := &github.TeamListTeamMembersOptions{
-		ListOptions: github.ListOptions{PerPage: 100},
+	teamSlug := slug.Make(team)
+	firstPageKey := fmt.Sprintf("/orgs/%s/teams/%s/members?per_page=100", t.organization, teamSlug)
+
+	opt := &gogithub.TeamListTeamMembersOptions{
+		ListOptions: gogithub.ListOptions{PerPage: 100},
 	}
 
 	userList := make([]string, 0)
 	for {
-		users, resp, err := t.service.ListTeamMembersBySlug(ctx, t.organization, slug.Make(team), opt)
+		users, resp, err := t.service.ListTeamMembersBySlug(ctx, t.organization, teamSlug, opt)
 		if err != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotModified {
+				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.organization, "team-members").Inc()
+				if cached, ok := t.cache.getValue(firstPageKey); ok {
+					if v, ok := cached.([]string); ok {
+						return v, nil
+					}
+				}
+				return []string{}, nil
+			}
 			return nil, err
 		}
 		for _, user := range users {
@@ -144,6 +209,11 @@ func (t DefaultTeamsProvider) Members(ctx context.Context, team string) ([]strin
 		opt.Page = resp.NextPage
 	}
 
+	if etag, ok := t.cache.getEtag(firstPageKey); ok && etag != "" {
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.organization, "team-members").Inc()
+		t.cache.set(firstPageKey, etag, userList)
+	}
+
 	return userList, nil
 }
 
@@ -152,7 +222,7 @@ func (t DefaultTeamsProvider) AddTeam(ctx context.Context, team string) error {
 	privacyLevel := "closed"
 	description := "membership to this team is managed by github-guard"
 
-	_, response, err := t.service.CreateTeam(ctx, t.organization, github.NewTeam{Name: team, Privacy: &privacyLevel, Description: &description})
+	_, response, err := t.service.CreateTeam(ctx, t.organization, gogithub.NewTeam{Name: team, Privacy: &privacyLevel, Description: &description})
 	if err != nil {
 		// Treat 422 "Name must be unique for this org" as success (team already exists)
 		if response != nil && response.StatusCode == 422 {

--- a/internal/github/teams.go
+++ b/internal/github/teams.go
@@ -129,7 +129,11 @@ func (t *DefaultTeamsProvider) List(ctx context.Context) ([]string, error) {
 func (t DefaultTeamsProvider) MembersExtended(ctx context.Context, team string) ([]GithubMember, error) {
 
 	teamSlug := slug.Make(team)
-	firstPageKey := fmt.Sprintf("/orgs/%s/teams/%s/members?per_page=100", t.organization, teamSlug)
+	// etagKey matches the URL used by the transport for If-None-Match injection.
+	// valueKey has a "#ext" suffix to avoid colliding with the Members() cache entry
+	// for the same URL, which stores []string (different type).
+	etagKey := fmt.Sprintf("/orgs/%s/teams/%s/members?per_page=100", t.organization, teamSlug)
+	valueKey := etagKey + "#ext"
 
 	opt := &gogithub.TeamListTeamMembersOptions{
 		ListOptions: gogithub.ListOptions{PerPage: 100},
@@ -141,13 +145,13 @@ func (t DefaultTeamsProvider) MembersExtended(ctx context.Context, team string) 
 		if err != nil {
 			if resp != nil && resp.StatusCode == http.StatusNotModified {
 				ghmetrics.EtagCacheHitsTotal.WithLabelValues(t.organization, "team-members-ext").Inc()
-				if cached, ok := t.cache.getValue(firstPageKey); ok {
+				if cached, ok := t.cache.getValue(valueKey); ok {
 					if v, ok := cached.([]GithubMember); ok {
 						return v, nil
 					}
 				}
-				t.cache.invalidate(firstPageKey)
-				return nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", firstPageKey)
+				t.cache.invalidate(valueKey)
+				return nil, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", valueKey)
 			}
 			return nil, err
 		}
@@ -163,9 +167,9 @@ func (t DefaultTeamsProvider) MembersExtended(ctx context.Context, team string) 
 		opt.Page = resp.NextPage
 	}
 
-	if etag, ok := t.cache.getEtag(firstPageKey); ok && etag != "" {
+	if etag, ok := t.cache.getEtag(etagKey); ok && etag != "" {
 		ghmetrics.EtagCacheMissesTotal.WithLabelValues(t.organization, "team-members-ext").Inc()
-		t.cache.set(firstPageKey, etag, userList)
+		t.cache.set(valueKey, etag, userList)
 	}
 
 	return userList, nil

--- a/internal/github/teams_test.go
+++ b/internal/github/teams_test.go
@@ -31,6 +31,7 @@ func newTestTeamsProvider(t *testing.T) (*DefaultTeamsProvider, *http.ServeMux) 
 	provider := &DefaultTeamsProvider{
 		service:      *client.Teams,
 		organization: "test-org",
+		cache:        &etagCache{entries: make(map[string]etagEntry)},
 	}
 	return provider, mux
 }

--- a/internal/github/users.go
+++ b/internal/github/users.go
@@ -32,10 +32,11 @@ type UsersProvider interface {
 }
 
 type DefaultUsersProvider struct {
-	service gogithub.UsersService
-	orgs    gogithub.OrganizationsService
-	http    *gogithub.Client // underlying go-github client to reuse its http.Client for GraphQL
-	cache   *etagCache
+	service    gogithub.UsersService // ETag-wrapped: used by GithubUsernameByID / GithubIDByUsername
+	rawService gogithub.UsersService // plain client: used by IsMemberOfOrg / HasVerifiedEmailDomainForGithubUID
+	orgs       gogithub.OrganizationsService
+	http       *gogithub.Client // underlying go-github client to reuse its http.Client for GraphQL
+	cache      *etagCache
 }
 
 func NewUsersProvider(cc githubapp.ClientCreator, installationID int64) (UsersProvider, error) {
@@ -71,10 +72,11 @@ func NewUsersProvider(cc githubapp.ClientCreator, installationID int64) (UsersPr
 	}
 
 	return &DefaultUsersProvider{
-		service: *etagClient.Users,
-		orgs:    *client.Organizations,
-		http:    client,
-		cache:   cache,
+		service:    *etagClient.Users,
+		rawService: *client.Users,
+		orgs:       *client.Organizations,
+		http:       client,
+		cache:      cache,
 	}, nil
 }
 
@@ -96,7 +98,7 @@ func (u *DefaultUsersProvider) GithubUsernameByID(id string) (string, bool, erro
 			return "", false, nil
 		}
 		if resp != nil && resp.StatusCode == http.StatusNotModified {
-			ghmetrics.EtagCacheHitsTotal.WithLabelValues("", "user-by-id").Inc()
+			ghmetrics.EtagCacheHitsTotal.WithLabelValues("__users__", "user-by-id").Inc()
 			if cached, ok := u.cache.getValue(userKey); ok {
 				if v, ok := cached.(string); ok {
 					return v, v != "", nil
@@ -110,7 +112,7 @@ func (u *DefaultUsersProvider) GithubUsernameByID(id string) (string, bool, erro
 
 	login := user.GetLogin()
 	if etag, ok := u.cache.getEtag(userKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues("", "user-by-id").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues("__users__", "user-by-id").Inc()
 		u.cache.set(userKey, etag, login)
 	}
 
@@ -129,7 +131,7 @@ func (u *DefaultUsersProvider) GithubIDByUsername(username string) (string, bool
 			return "", false, nil
 		}
 		if resp != nil && resp.StatusCode == http.StatusNotModified {
-			ghmetrics.EtagCacheHitsTotal.WithLabelValues("", "user-by-login").Inc()
+			ghmetrics.EtagCacheHitsTotal.WithLabelValues("__users__", "user-by-login").Inc()
 			if cached, ok := u.cache.getValue(loginKey); ok {
 				if v, ok := cached.(string); ok {
 					return v, v != "", nil
@@ -144,7 +146,7 @@ func (u *DefaultUsersProvider) GithubIDByUsername(username string) (string, bool
 	// convert numeric ID to string
 	idStr := strconv.FormatInt(user.GetID(), 10)
 	if etag, ok := u.cache.getEtag(loginKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues("", "user-by-login").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues("__users__", "user-by-login").Inc()
 		u.cache.set(loginKey, etag, idStr)
 	}
 
@@ -156,7 +158,7 @@ func (u *DefaultUsersProvider) IsMemberOfOrg(ctx context.Context, org string, ui
 	if err != nil {
 		return false, fmt.Errorf("invalid GitHub user ID: %q (expected numeric ID): %w", uid, err)
 	}
-	user, resp, err := u.service.GetByID(ctx, userID)
+	user, resp, err := u.rawService.GetByID(ctx, userID)
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			return false, nil
@@ -193,7 +195,7 @@ func (u *DefaultUsersProvider) HasVerifiedEmailDomainForGithubUID(ctx context.Co
 	if err != nil {
 		return false, fmt.Errorf("invalid GitHub user ID: %q (expected numeric ID): %w", uid, err)
 	}
-	user, resp, err := u.service.GetByID(ctx, userID)
+	user, resp, err := u.rawService.GetByID(ctx, userID)
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			return false, nil

--- a/internal/github/users.go
+++ b/internal/github/users.go
@@ -102,7 +102,8 @@ func (u *DefaultUsersProvider) GithubUsernameByID(id string) (string, bool, erro
 					return v, v != "", nil
 				}
 			}
-			return "", false, nil
+			u.cache.invalidate(userKey)
+			return "", false, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", userKey)
 		}
 		return "", false, err
 	}
@@ -134,7 +135,8 @@ func (u *DefaultUsersProvider) GithubIDByUsername(username string) (string, bool
 					return v, v != "", nil
 				}
 			}
-			return "", false, nil
+			u.cache.invalidate(loginKey)
+			return "", false, fmt.Errorf("etag cache inconsistency for %s: 304 received but no valid cached value", loginKey)
 		}
 		return "", false, err
 	}

--- a/internal/github/users.go
+++ b/internal/github/users.go
@@ -52,7 +52,7 @@ func NewUsersProvider(cc githubapp.ClientCreator, installationID int64) (UsersPr
 	}
 
 	// Users provider uses a shared cache keyed by "users" since it's not org-specific.
-	cache := getOrCreateOrgCache("__users__")
+	cache := getOrCreateOrgCache("__users__", "__users__")
 
 	// Clone the client with an ETag transport for conditional GET caching.
 	baseHTTP := client.Client()
@@ -98,7 +98,7 @@ func (u *DefaultUsersProvider) GithubUsernameByID(id string) (string, bool, erro
 			return "", false, nil
 		}
 		if resp != nil && resp.StatusCode == http.StatusNotModified {
-			ghmetrics.EtagCacheHitsTotal.WithLabelValues("__users__", "user-by-id").Inc()
+			ghmetrics.EtagCacheHitsTotal.WithLabelValues("__users__", "__users__", "user-by-id").Inc()
 			if cached, ok := u.cache.getValue(userKey); ok {
 				if v, ok := cached.(string); ok {
 					return v, v != "", nil
@@ -112,7 +112,7 @@ func (u *DefaultUsersProvider) GithubUsernameByID(id string) (string, bool, erro
 
 	login := user.GetLogin()
 	if etag, ok := u.cache.getEtag(userKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues("__users__", "user-by-id").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues("__users__", "__users__", "user-by-id").Inc()
 		u.cache.set(userKey, etag, login)
 	}
 
@@ -131,7 +131,7 @@ func (u *DefaultUsersProvider) GithubIDByUsername(username string) (string, bool
 			return "", false, nil
 		}
 		if resp != nil && resp.StatusCode == http.StatusNotModified {
-			ghmetrics.EtagCacheHitsTotal.WithLabelValues("__users__", "user-by-login").Inc()
+			ghmetrics.EtagCacheHitsTotal.WithLabelValues("__users__", "__users__", "user-by-login").Inc()
 			if cached, ok := u.cache.getValue(loginKey); ok {
 				if v, ok := cached.(string); ok {
 					return v, v != "", nil
@@ -146,7 +146,7 @@ func (u *DefaultUsersProvider) GithubIDByUsername(username string) (string, bool
 	// convert numeric ID to string
 	idStr := strconv.FormatInt(user.GetID(), 10)
 	if etag, ok := u.cache.getEtag(loginKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues("__users__", "user-by-login").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues("__users__", "__users__", "user-by-login").Inc()
 		u.cache.set(loginKey, etag, idStr)
 	}
 

--- a/internal/github/users.go
+++ b/internal/github/users.go
@@ -36,10 +36,11 @@ type DefaultUsersProvider struct {
 	rawService gogithub.UsersService // plain client: used by IsMemberOfOrg / HasVerifiedEmailDomainForGithubUID
 	orgs       gogithub.OrganizationsService
 	http       *gogithub.Client // underlying go-github client to reuse its http.Client for GraphQL
+	githubName string
 	cache      *etagCache
 }
 
-func NewUsersProvider(cc githubapp.ClientCreator, installationID int64) (UsersProvider, error) {
+func NewUsersProvider(cc githubapp.ClientCreator, githubName string, installationID int64) (UsersProvider, error) {
 	client, err := cc.NewInstallationClient(installationID)
 	if err != nil {
 		return nil, err
@@ -51,8 +52,9 @@ func NewUsersProvider(cc githubapp.ClientCreator, installationID int64) (UsersPr
 		return nil, errors.New("empty organizations service")
 	}
 
-	// Users provider uses a shared cache keyed by "users" since it's not org-specific.
-	cache := getOrCreateOrgCache("__users__", "__users__")
+	// Users lookups are not org-specific, but we still key the cache by GitHub instance
+	// so that separate GitHub instances (github.com vs GHE) never share ETags or user data.
+	cache := getOrCreateOrgCache(githubName, "__users__")
 
 	// Clone the client with an ETag transport for conditional GET caching.
 	baseHTTP := client.Client()
@@ -76,6 +78,7 @@ func NewUsersProvider(cc githubapp.ClientCreator, installationID int64) (UsersPr
 		rawService: *client.Users,
 		orgs:       *client.Organizations,
 		http:       client,
+		githubName: githubName,
 		cache:      cache,
 	}, nil
 }
@@ -98,7 +101,7 @@ func (u *DefaultUsersProvider) GithubUsernameByID(id string) (string, bool, erro
 			return "", false, nil
 		}
 		if resp != nil && resp.StatusCode == http.StatusNotModified {
-			ghmetrics.EtagCacheHitsTotal.WithLabelValues("__users__", "__users__", "user-by-id").Inc()
+			ghmetrics.EtagCacheHitsTotal.WithLabelValues(u.githubName, "__users__", "user-by-id").Inc()
 			if cached, ok := u.cache.getValue(userKey); ok {
 				if v, ok := cached.(string); ok {
 					return v, v != "", nil
@@ -112,7 +115,7 @@ func (u *DefaultUsersProvider) GithubUsernameByID(id string) (string, bool, erro
 
 	login := user.GetLogin()
 	if etag, ok := u.cache.getEtag(userKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues("__users__", "__users__", "user-by-id").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(u.githubName, "__users__", "user-by-id").Inc()
 		u.cache.set(userKey, etag, login)
 	}
 
@@ -131,7 +134,7 @@ func (u *DefaultUsersProvider) GithubIDByUsername(username string) (string, bool
 			return "", false, nil
 		}
 		if resp != nil && resp.StatusCode == http.StatusNotModified {
-			ghmetrics.EtagCacheHitsTotal.WithLabelValues("__users__", "__users__", "user-by-login").Inc()
+			ghmetrics.EtagCacheHitsTotal.WithLabelValues(u.githubName, "__users__", "user-by-login").Inc()
 			if cached, ok := u.cache.getValue(loginKey); ok {
 				if v, ok := cached.(string); ok {
 					return v, v != "", nil
@@ -146,7 +149,7 @@ func (u *DefaultUsersProvider) GithubIDByUsername(username string) (string, bool
 	// convert numeric ID to string
 	idStr := strconv.FormatInt(user.GetID(), 10)
 	if etag, ok := u.cache.getEtag(loginKey); ok && etag != "" {
-		ghmetrics.EtagCacheMissesTotal.WithLabelValues("__users__", "__users__", "user-by-login").Inc()
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues(u.githubName, "__users__", "user-by-login").Inc()
 		u.cache.set(loginKey, etag, idStr)
 	}
 

--- a/internal/github/users.go
+++ b/internal/github/users.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v88/github"
+	gogithub "github.com/google/go-github/v88/github"
 	"github.com/palantir/go-githubapp/githubapp"
 	githubv4 "github.com/shurcooL/githubv4"
+
+	ghmetrics "github.com/cloudoperators/repo-guard/internal/metrics"
 )
 
 type UsersProvider interface {
@@ -29,9 +32,10 @@ type UsersProvider interface {
 }
 
 type DefaultUsersProvider struct {
-	service github.UsersService
-	orgs    github.OrganizationsService
-	http    *github.Client // underlying go-github client to reuse its http.Client for GraphQL
+	service gogithub.UsersService
+	orgs    gogithub.OrganizationsService
+	http    *gogithub.Client // underlying go-github client to reuse its http.Client for GraphQL
+	cache   *etagCache
 }
 
 func NewUsersProvider(cc githubapp.ClientCreator, installationID int64) (UsersProvider, error) {
@@ -46,7 +50,32 @@ func NewUsersProvider(cc githubapp.ClientCreator, installationID int64) (UsersPr
 		return nil, errors.New("empty organizations service")
 	}
 
-	return &DefaultUsersProvider{service: *client.Users, orgs: *client.Organizations, http: client}, nil
+	// Users provider uses a shared cache keyed by "users" since it's not org-specific.
+	cache := getOrCreateOrgCache("__users__")
+
+	// Clone the client with an ETag transport for conditional GET caching.
+	baseHTTP := client.Client()
+	baseTransport := baseHTTP.Transport
+	if baseTransport == nil {
+		baseTransport = http.DefaultTransport
+	}
+	etagHTTP := &http.Client{
+		Transport:     &etagTransport{wrapped: baseTransport, cache: cache, keyFn: urlCacheKey},
+		CheckRedirect: baseHTTP.CheckRedirect,
+		Jar:           baseHTTP.Jar,
+		Timeout:       baseHTTP.Timeout,
+	}
+	etagClient, err := client.Clone(gogithub.WithHTTPClient(etagHTTP))
+	if err != nil {
+		return nil, fmt.Errorf("clone github client with etag transport: %w", err)
+	}
+
+	return &DefaultUsersProvider{
+		service: *etagClient.Users,
+		orgs:    *client.Organizations,
+		http:    client,
+		cache:   cache,
+	}, nil
 }
 
 // GithubUsernameByID returns the GitHub login for a given GitHub user ID.
@@ -58,34 +87,66 @@ func (u *DefaultUsersProvider) GithubUsernameByID(id string) (string, bool, erro
 		return "", false, fmt.Errorf("invalid GitHub user ID: %q (expected numeric ID): %w", id, err)
 	}
 
+	userKey := fmt.Sprintf("/user/%s", id)
+
 	// fetch the user by ID
 	user, resp, err := u.service.GetByID(context.Background(), userID)
 	if err != nil {
-		// if not found, return found=false
 		if resp != nil && resp.StatusCode == 404 {
+			return "", false, nil
+		}
+		if resp != nil && resp.StatusCode == http.StatusNotModified {
+			ghmetrics.EtagCacheHitsTotal.WithLabelValues("", "user-by-id").Inc()
+			if cached, ok := u.cache.getValue(userKey); ok {
+				if v, ok := cached.(string); ok {
+					return v, v != "", nil
+				}
+			}
 			return "", false, nil
 		}
 		return "", false, err
 	}
 
-	return user.GetLogin(), true, nil
+	login := user.GetLogin()
+	if etag, ok := u.cache.getEtag(userKey); ok && etag != "" {
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues("", "user-by-id").Inc()
+		u.cache.set(userKey, etag, login)
+	}
+
+	return login, true, nil
 }
 
 // GithubIDByUsername returns the GitHub user ID string for a given login.
 // It returns (id, found, error).
 func (u *DefaultUsersProvider) GithubIDByUsername(username string) (string, bool, error) {
+	loginKey := fmt.Sprintf("/users/%s", username)
+
 	// fetch the user by login name
 	user, resp, err := u.service.Get(context.Background(), username)
 	if err != nil {
-		// if not found, return found=false
 		if resp != nil && resp.StatusCode == 404 {
+			return "", false, nil
+		}
+		if resp != nil && resp.StatusCode == http.StatusNotModified {
+			ghmetrics.EtagCacheHitsTotal.WithLabelValues("", "user-by-login").Inc()
+			if cached, ok := u.cache.getValue(loginKey); ok {
+				if v, ok := cached.(string); ok {
+					return v, v != "", nil
+				}
+			}
 			return "", false, nil
 		}
 		return "", false, err
 	}
 
 	// convert numeric ID to string
-	return strconv.FormatInt(user.GetID(), 10), true, nil
+	idStr := strconv.FormatInt(user.GetID(), 10)
+	if etag, ok := u.cache.getEtag(loginKey); ok && etag != "" {
+		ghmetrics.EtagCacheMissesTotal.WithLabelValues("", "user-by-login").Inc()
+		u.cache.set(loginKey, etag, idStr)
+	}
+
+	return idStr, true, nil
 }
 
 func (u *DefaultUsersProvider) IsMemberOfOrg(ctx context.Context, org string, uid string) (bool, error) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -191,7 +191,7 @@ var (
 			Name:      "graphql_calls_total",
 			Help:      "Total number of GitHub GraphQL API calls, by organization and result.",
 		},
-		[]string{"org", "result"},
+		[]string{"organization", "result"},
 	)
 
 	// ETag conditional-request counters (Track 2: #141)
@@ -202,7 +202,7 @@ var (
 			Name:      "etag_cache_hits_total",
 			Help:      "Total number of GitHub REST requests that returned HTTP 304 (ETag cache hit).",
 		},
-		[]string{"org", "endpoint"},
+		[]string{"organization", "endpoint"},
 	)
 
 	EtagCacheMissesTotal = prometheus.NewCounterVec(
@@ -212,7 +212,7 @@ var (
 			Name:      "etag_cache_misses_total",
 			Help:      "Total number of GitHub REST requests that returned HTTP 200 (ETag cache miss or first fetch).",
 		},
-		[]string{"org", "endpoint"},
+		[]string{"organization", "endpoint"},
 	)
 )
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -182,6 +182,38 @@ var (
 		},
 		[]string{"github", "organization"},
 	)
+
+	// GraphQL bulk fetch counters (Track 1: #149)
+	GraphQLCallsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "repo_guard",
+			Subsystem: "github",
+			Name:      "graphql_calls_total",
+			Help:      "Total number of GitHub GraphQL API calls, by organization and result.",
+		},
+		[]string{"org", "result"},
+	)
+
+	// ETag conditional-request counters (Track 2: #141)
+	EtagCacheHitsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "repo_guard",
+			Subsystem: "github",
+			Name:      "etag_cache_hits_total",
+			Help:      "Total number of GitHub REST requests that returned HTTP 304 (ETag cache hit).",
+		},
+		[]string{"org", "endpoint"},
+	)
+
+	EtagCacheMissesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "repo_guard",
+			Subsystem: "github",
+			Name:      "etag_cache_misses_total",
+			Help:      "Total number of GitHub REST requests that returned HTTP 200 (ETag cache miss or first fetch).",
+		},
+		[]string{"org", "endpoint"},
+	)
 )
 
 func init() {
@@ -202,6 +234,9 @@ func init() {
 		RateLimitHitsTotal,
 		RateLimitBackoffSeconds,
 		PendingOperationsTotal,
+		GraphQLCallsTotal,
+		EtagCacheHitsTotal,
+		EtagCacheMissesTotal,
 	)
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -189,7 +189,7 @@ var (
 			Namespace: "repo_guard",
 			Subsystem: "github",
 			Name:      "graphql_calls_total",
-			Help:      "Total number of GitHub GraphQL API calls, by github instance, organization and result.",
+			Help:      "Total number of GitHub GraphQL API calls made by ExtendedListGraphQL (repo bulk fetch), by github instance, organization and result.",
 		},
 		[]string{"github", "organization", "result"},
 	)
@@ -210,7 +210,7 @@ var (
 			Namespace: "repo_guard",
 			Subsystem: "github",
 			Name:      "etag_cache_misses_total",
-			Help:      "Total number of GitHub REST requests that returned HTTP 200 (ETag cache miss or first fetch).",
+			Help:      "Total number of GitHub REST requests that returned HTTP 200 with a cacheable ETag (cache miss or first fetch).",
 		},
 		[]string{"github", "organization", "endpoint"},
 	)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -189,9 +189,9 @@ var (
 			Namespace: "repo_guard",
 			Subsystem: "github",
 			Name:      "graphql_calls_total",
-			Help:      "Total number of GitHub GraphQL API calls, by organization and result.",
+			Help:      "Total number of GitHub GraphQL API calls, by github instance, organization and result.",
 		},
-		[]string{"organization", "result"},
+		[]string{"github", "organization", "result"},
 	)
 
 	// ETag conditional-request counters (Track 2: #141)
@@ -202,7 +202,7 @@ var (
 			Name:      "etag_cache_hits_total",
 			Help:      "Total number of GitHub REST requests that returned HTTP 304 (ETag cache hit).",
 		},
-		[]string{"organization", "endpoint"},
+		[]string{"github", "organization", "endpoint"},
 	)
 
 	EtagCacheMissesTotal = prometheus.NewCounterVec(
@@ -212,7 +212,7 @@ var (
 			Name:      "etag_cache_misses_total",
 			Help:      "Total number of GitHub REST requests that returned HTTP 200 (ETag cache miss or first fetch).",
 		},
-		[]string{"organization", "endpoint"},
+		[]string{"github", "organization", "endpoint"},
 	)
 )
 


### PR DESCRIPTION
Closes #149, closes #141, part of epic #150.

## Summary

- **GraphQL bulk fetch** replaces the N+1 REST pattern in `ExtendedList()`: a single paginated GraphQL query now fetches all repos + their team permissions in 3–4 calls instead of 303 for a 300-repo org.
- **ETag conditional requests** add a package-level per-org cache (survives reconcile cycles) so unchanged list responses return HTTP 304 and the controller reuses the last parsed result, eliminating redundant API calls between reconciles.
- **Metrics**: new `etag_cache_hits_total`, `etag_cache_misses_total`, and `graphql_calls_total` Prometheus counters wired at every relevant code path.

## Changes

| Area | What changed |
|---|---|
| `internal/github/repos_graphql.go` | New: `ExtendedListGraphQL()`, GraphQL query struct, permission mapping (`WRITE→push`), pagination with per-repo REST fallback when teams > 100 |
| `internal/github/etag_cache.go` | New: package-level `sync.Map` of `*etagCache` keyed by org; stores ETag + parsed value per URL key |
| `internal/github/etag_transport.go` | New: `http.RoundTripper` that injects `If-None-Match` on GETs and captures `ETag` from 200 responses |
| `internal/github/{repos,teams,organizations,users}.go` | Wrapped HTTP clients with ETag transport; 304 code paths return cached results |
| `internal/controller/github_controller.go` | Derives `cfg.V4APIURL` from `V3APIURL` so `NewInstallationV4Client` points at the correct endpoint |
| `internal/controller/githuborganization_controller.go` | Calls `ExtendedListGraphQL()` instead of `ExtendedList()` |
| `internal/controller/utils.go` | Rate-limit parser handles GraphQL error strings |
| `internal/metrics/metrics.go` | New ETag hit/miss and GraphQL call counters |

## Test plan

- [ ] `make controller-test` — all 31 Ginkgo specs pass under `GITHUB_MOCK=true`
- [ ] `go test ./internal/github/... -run TestEtag` — ETag cache and transport unit tests
- [ ] `go test ./internal/github/... -run TestGraphql` — GraphQL permission mapping and pagination tests
- [ ] `go test ./internal/github/... -run TestExtendedList` — archived/disabled filtering and team overflow fallback
- [ ] `make lint` passes