### PR TITLE
fix(github): replace invalid Repository.teams GraphQL field

### DIFF
--- a/internal/github/mock_server.go
+++ b/internal/github/mock_server.go
@@ -969,6 +969,21 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 					},
 				})
 			}
+			// Also emit nodes for team slugs that appear only in teamRepoPerms
+			// (e.g. teams created dynamically via REST and not seeded in cfg.Teams).
+			for slug, edges := range teamRepoEdges {
+				if seen[slug] {
+					continue
+				}
+				seen[slug] = true
+				teamNodes = append(teamNodes, map[string]any{
+					"slug": slug,
+					"repositories": map[string]any{
+						"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+						"edges":    edges,
+					},
+				})
+			}
 			resp := map[string]any{
 				"data": map[string]any{
 					"organization": map[string]any{

--- a/internal/github/mock_server.go
+++ b/internal/github/mock_server.go
@@ -883,53 +883,127 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 
 	// ---- GraphQL ----
 
-	// POST /api/graphql  — serves the orgReposWithTeamsQuery used by ExtendedListGraphQL.
-	// The mock returns all repos in a single page (no pagination) with their team permissions.
+	// POST /api/graphql  — serves the two-query pattern used by ExtendedListGraphQL:
+	//   1. orgTeamsWithReposQuery  (variables contain "teamCursor")  → organization.teams shape
+	//   2. teamReposQuery          (variables contain "teamSlug")    → organization.team shape
+	//   3. orgReposQuery           (neither above)                   → organization.repositories shape
 	mux.HandleFunc("/api/graphql", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 
+		// Decode the request to inspect the variables map.
+		var req struct {
+			Variables map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
 		stateMu.Lock()
-		snapshot := make([]MockRepo, len(repos))
-		copy(snapshot, repos)
+		reposSnap := make([]MockRepo, len(repos))
+		copy(reposSnap, repos)
+		teamsSnap := make([]MockTeam, len(teams))
+		copy(teamsSnap, teams)
+		permsSnap := make(map[string][]MockTeamWithPermission, len(teamRepoPerms))
+		for k, v := range teamRepoPerms {
+			cp := make([]MockTeamWithPermission, len(v))
+			copy(cp, v)
+			permsSnap[k] = cp
+		}
 		stateMu.Unlock()
 
-		nodes := make([]map[string]any, 0, len(snapshot))
-		for _, repo := range snapshot {
-			// Archived and disabled repos are included in the response;
-			// ExtendedListGraphQL itself filters them out (same as REST path).
-			teamEdges := make([]map[string]any, 0, len(repo.Teams))
-			for _, tp := range repo.Teams {
-				teamEdges = append(teamEdges, map[string]any{
-					"permission": restPermissionToGraphQL(tp.Permission),
-					"node":       map[string]any{"slug": tp.Slug},
-				})
-			}
-			nodes = append(nodes, map[string]any{
-				"name":       repo.Name,
-				"visibility": strings.ToUpper(repo.repoVisibility()),
-				"isArchived": repo.Archived,
-				"isDisabled": repo.Disabled,
-				"teams": map[string]any{
-					"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
-					"edges":    teamEdges,
-				},
-			})
-		}
+		_, hasTeamCursor := req.Variables["teamCursor"]
+		_, hasTeamSlug := req.Variables["teamSlug"]
 
-		resp := map[string]any{
-			"data": map[string]any{
-				"organization": map[string]any{
-					"repositories": map[string]any{
-						"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
-						"nodes":    nodes,
+		switch {
+		case hasTeamSlug:
+			// teamReposQuery — single-team overflow pagination. Return an empty page;
+			// the mock never seeds teams with >100 repos so this path is not exercised
+			// in controller tests.
+			resp := map[string]any{
+				"data": map[string]any{
+					"organization": map[string]any{
+						"team": map[string]any{
+							"repositories": map[string]any{
+								"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+								"edges":    []any{},
+							},
+						},
 					},
 				},
-			},
+			}
+			writeJSON(w, resp)
+
+		case hasTeamCursor:
+			// orgTeamsWithReposQuery — build a team → repo edges map from teamRepoPerms.
+			// Invert permsSnap (repoName→teams) into teamSlug→[]repoEdge.
+			teamRepoEdges := make(map[string][]map[string]any)
+			for repoName, perms := range permsSnap {
+				for _, tp := range perms {
+					teamRepoEdges[tp.Slug] = append(teamRepoEdges[tp.Slug], map[string]any{
+						"permission": restPermissionToGraphQL(tp.Permission),
+						"node":       map[string]any{"name": repoName},
+					})
+				}
+			}
+			// Build nodes — one entry per known team slug (union of seeded teams + perms).
+			seen := make(map[string]bool)
+			teamNodes := []map[string]any{}
+			for _, t := range teamsSnap {
+				if seen[t.Slug] {
+					continue
+				}
+				seen[t.Slug] = true
+				edges := teamRepoEdges[t.Slug]
+				if edges == nil {
+					edges = []map[string]any{}
+				}
+				teamNodes = append(teamNodes, map[string]any{
+					"slug": t.Slug,
+					"repositories": map[string]any{
+						"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+						"edges":    edges,
+					},
+				})
+			}
+			resp := map[string]any{
+				"data": map[string]any{
+					"organization": map[string]any{
+						"teams": map[string]any{
+							"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+							"nodes":    teamNodes,
+						},
+					},
+				},
+			}
+			writeJSON(w, resp)
+
+		default:
+			// orgReposQuery — metadata only, no teams field.
+			nodes := make([]map[string]any, 0, len(reposSnap))
+			for _, repo := range reposSnap {
+				nodes = append(nodes, map[string]any{
+					"name":       repo.Name,
+					"visibility": strings.ToUpper(repo.repoVisibility()),
+					"isArchived": repo.Archived,
+					"isDisabled": repo.Disabled,
+				})
+			}
+			resp := map[string]any{
+				"data": map[string]any{
+					"organization": map[string]any{
+						"repositories": map[string]any{
+							"pageInfo": map[string]any{"hasNextPage": false, "endCursor": ""},
+							"nodes":    nodes,
+						},
+					},
+				},
+			}
+			writeJSON(w, resp)
 		}
-		writeJSON(w, resp)
 	})
 }
 

--- a/internal/github/repos_graphql.go
+++ b/internal/github/repos_graphql.go
@@ -13,9 +13,56 @@ import (
 	ghmetrics "github.com/cloudoperators/repo-guard/internal/metrics"
 )
 
-// orgReposWithTeamsQuery is the GraphQL query struct for fetching all organisation
-// repositories and their associated team permissions in a single paginated request.
-type orgReposWithTeamsQuery struct {
+// orgTeamsWithReposQuery is the GraphQL query struct for fetching all organisation
+// teams and their associated repository permissions. GitHub's GraphQL API does not
+// expose a `teams` field on the Repository type; the traversal must go the other
+// way: organisation → teams → repositories.
+type orgTeamsWithReposQuery struct {
+	Organization struct {
+		Teams struct {
+			PageInfo struct {
+				HasNextPage githubv4.Boolean
+				EndCursor   githubv4.String
+			}
+			Nodes []struct {
+				Slug         githubv4.String
+				Repositories struct {
+					PageInfo struct {
+						HasNextPage githubv4.Boolean
+						EndCursor   githubv4.String
+					}
+					Edges []struct {
+						Permission githubv4.String
+						Node       struct{ Name githubv4.String }
+					}
+				} `graphql:"repositories(first: 100, after: $repoCursor, orderBy: {field: NAME, direction: ASC})"`
+			}
+		} `graphql:"teams(first: 100, after: $teamCursor)"`
+	} `graphql:"organization(login: $org)"`
+}
+
+// teamReposQuery is the GraphQL query struct for fetching repositories of a
+// single team. Used as a fallback when a team has more than 100 repositories.
+type teamReposQuery struct {
+	Organization struct {
+		Team struct {
+			Repositories struct {
+				PageInfo struct {
+					HasNextPage githubv4.Boolean
+					EndCursor   githubv4.String
+				}
+				Edges []struct {
+					Permission githubv4.String
+					Node       struct{ Name githubv4.String }
+				}
+			} `graphql:"repositories(first: 100, after: $repoCursor, orderBy: {field: NAME, direction: ASC})"`
+		} `graphql:"team(slug: $teamSlug)"`
+	} `graphql:"organization(login: $org)"`
+}
+
+// orgReposQuery is the GraphQL query struct for fetching all organisation
+// repositories with their metadata (name, visibility, archived, disabled).
+type orgReposQuery struct {
 	Organization struct {
 		Repositories struct {
 			PageInfo struct {
@@ -27,16 +74,6 @@ type orgReposWithTeamsQuery struct {
 				Visibility githubv4.String
 				IsArchived githubv4.Boolean
 				IsDisabled githubv4.Boolean
-				Teams      struct {
-					PageInfo struct {
-						HasNextPage githubv4.Boolean
-						EndCursor   githubv4.String
-					}
-					Edges []struct {
-						Permission githubv4.String
-						Node       struct{ Slug githubv4.String }
-					}
-				} `graphql:"teams(first: 100, after: $teamCursor)"`
 			}
 		} `graphql:"repositories(first: 100, after: $repoCursor, orderBy: {field: NAME, direction: ASC})"`
 	} `graphql:"organization(login: $org)"`
@@ -63,26 +100,127 @@ func graphqlPermissionToTeamPermission(p string) repoguardsapv1.GithubTeamPermis
 	}
 }
 
+// buildRepoTeamsMap fetches all organisation teams and their repositories via
+// GraphQL and returns a map of repository name → team permissions.
+// Teams with more than 100 repositories fall back to a dedicated single-team
+// query so that the repoCursor is scoped to that team only.
+func (t *DefaultRepositoryProvider) buildRepoTeamsMap(ctx context.Context) (map[string][]repoguardsapv1.GithubTeamWithPermission, error) {
+	repoTeams := make(map[string][]repoguardsapv1.GithubTeamWithPermission)
+
+	var teamCursor *githubv4.String
+	for {
+		var query orgTeamsWithReposQuery
+		vars := map[string]any{
+			"org":        githubv4.String(t.organization),
+			"teamCursor": teamCursor,
+			"repoCursor": (*githubv4.String)(nil),
+		}
+
+		if err := t.graphqlClient.Query(ctx, &query, vars); err != nil {
+			ghmetrics.GraphQLCallsTotal.WithLabelValues(t.githubName, t.organization, "error").Inc()
+			return nil, err
+		}
+		ghmetrics.GraphQLCallsTotal.WithLabelValues(t.githubName, t.organization, "success").Inc()
+
+		for _, team := range query.Organization.Teams.Nodes {
+			slug := string(team.Slug)
+			if slug == "" {
+				continue
+			}
+
+			for _, edge := range team.Repositories.Edges {
+				repoName := string(edge.Node.Name)
+				if repoName == "" {
+					continue
+				}
+				perm := graphqlPermissionToTeamPermission(string(edge.Permission))
+				repoTeams[repoName] = append(repoTeams[repoName], repoguardsapv1.GithubTeamWithPermission{
+					Team:       slug,
+					Permission: perm,
+				})
+			}
+
+			// Rare edge case: team has >100 repos. Use a dedicated single-team
+			// query so the repoCursor applies only to this team.
+			if bool(team.Repositories.PageInfo.HasNextPage) {
+				if err := t.fetchRemainingTeamRepos(ctx, slug, team.Repositories.PageInfo.EndCursor, repoTeams); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		if !bool(query.Organization.Teams.PageInfo.HasNextPage) {
+			break
+		}
+		cursor := query.Organization.Teams.PageInfo.EndCursor
+		teamCursor = &cursor
+	}
+
+	return repoTeams, nil
+}
+
+// fetchRemainingTeamRepos paginates through the remaining repositories for a
+// single team (slug) starting from afterCursor, appending results to repoTeams.
+func (t *DefaultRepositoryProvider) fetchRemainingTeamRepos(ctx context.Context, slug string, afterCursor githubv4.String, repoTeams map[string][]repoguardsapv1.GithubTeamWithPermission) error {
+	cursor := afterCursor
+	for {
+		var query teamReposQuery
+		vars := map[string]any{
+			"org":        githubv4.String(t.organization),
+			"teamSlug":   githubv4.String(slug),
+			"repoCursor": &cursor,
+		}
+		if err := t.graphqlClient.Query(ctx, &query, vars); err != nil {
+			ghmetrics.GraphQLCallsTotal.WithLabelValues(t.githubName, t.organization, "error").Inc()
+			return err
+		}
+		ghmetrics.GraphQLCallsTotal.WithLabelValues(t.githubName, t.organization, "success").Inc()
+
+		for _, edge := range query.Organization.Team.Repositories.Edges {
+			repoName := string(edge.Node.Name)
+			if repoName == "" {
+				continue
+			}
+			perm := graphqlPermissionToTeamPermission(string(edge.Permission))
+			repoTeams[repoName] = append(repoTeams[repoName], repoguardsapv1.GithubTeamWithPermission{
+				Team:       slug,
+				Permission: perm,
+			})
+		}
+
+		if !bool(query.Organization.Team.Repositories.PageInfo.HasNextPage) {
+			break
+		}
+		cursor = query.Organization.Team.Repositories.PageInfo.EndCursor
+	}
+	return nil
+}
+
 // ExtendedListGraphQL fetches all organisation repositories and their team permissions
-// using a single paginated GraphQL query instead of N+1 REST calls.
-// For 300 repositories this reduces ~303 REST calls to 3–4 GraphQL calls per reconcile.
+// using GraphQL queries instead of N+1 REST calls.
+// For 300 repositories this significantly reduces REST API consumption per reconcile.
 //
 // Repos that are archived or disabled are excluded (same semantics as List/ExtendedList).
-// If a repository has more than 100 teams (extremely rare), the method falls back to a
-// REST call for that specific repository only.
+// Team permissions are gathered by traversing organisation → teams → repositories, since
+// GitHub's GraphQL API does not expose a `teams` field on the Repository type.
 func (t *DefaultRepositoryProvider) ExtendedListGraphQL(ctx context.Context) ([]repoguardsapv1.GithubRepository, []repoguardsapv1.GithubRepository, []repoguardsapv1.GithubRepository, error) {
+	// Step 1: build a map of repo name → teams from the teams side.
+	repoTeams, err := t.buildRepoTeamsMap(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	publicRepos := make([]repoguardsapv1.GithubRepository, 0)
 	privateRepos := make([]repoguardsapv1.GithubRepository, 0)
 	internalRepos := make([]repoguardsapv1.GithubRepository, 0)
 
-	var repoCursor *githubv4.String // nil = first page
-
+	// Step 2: list all repositories with their metadata.
+	var repoCursor *githubv4.String
 	for {
-		var query orgReposWithTeamsQuery
+		var query orgReposQuery
 		vars := map[string]any{
 			"org":        githubv4.String(t.organization),
 			"repoCursor": repoCursor,
-			"teamCursor": (*githubv4.String)(nil),
 		}
 
 		if err := t.graphqlClient.Query(ctx, &query, vars); err != nil {
@@ -100,27 +238,9 @@ func (t *DefaultRepositoryProvider) ExtendedListGraphQL(ctx context.Context) ([]
 				continue
 			}
 
-			var teams []repoguardsapv1.GithubTeamWithPermission
-			if bool(node.Teams.PageInfo.HasNextPage) {
-				// Rare edge case: repo has >100 teams. Fall back to REST for this repo.
-				var err error
-				teams, err = t.RepositoryTeams(ctx, name)
-				if err != nil {
-					return nil, nil, nil, err
-				}
-			} else {
-				teams = make([]repoguardsapv1.GithubTeamWithPermission, 0, len(node.Teams.Edges))
-				for _, edge := range node.Teams.Edges {
-					slug := string(edge.Node.Slug)
-					if slug == "" {
-						continue
-					}
-					perm := graphqlPermissionToTeamPermission(string(edge.Permission))
-					teams = append(teams, repoguardsapv1.GithubTeamWithPermission{
-						Team:       slug,
-						Permission: perm,
-					})
-				}
+			teams := repoTeams[name] // nil → empty slice is fine
+			if teams == nil {
+				teams = []repoguardsapv1.GithubTeamWithPermission{}
 			}
 
 			repo := repoguardsapv1.GithubRepository{Name: name, Teams: teams}

--- a/internal/github/repos_graphql.go
+++ b/internal/github/repos_graphql.go
@@ -159,6 +159,11 @@ func (t *DefaultRepositoryProvider) buildRepoTeamsMap(ctx context.Context) (map[
 			break
 		}
 		cursor := query.Organization.Teams.PageInfo.EndCursor
+		if cursor == "" {
+			// Guard: malformed response with HasNextPage=true but empty cursor;
+			// stop to avoid repeating the same page indefinitely.
+			break
+		}
 		teamCursor = &cursor
 	}
 
@@ -203,7 +208,13 @@ func (t *DefaultRepositoryProvider) fetchRemainingTeamRepos(ctx context.Context,
 		if !bool(query.Organization.Team.Repositories.PageInfo.HasNextPage) {
 			break
 		}
-		cursor = query.Organization.Team.Repositories.PageInfo.EndCursor
+		nextCursor := query.Organization.Team.Repositories.PageInfo.EndCursor
+		if nextCursor == "" {
+			// Guard: malformed response with HasNextPage=true but empty cursor;
+			// stop to avoid re-fetching the same page and duplicating results.
+			break
+		}
+		cursor = nextCursor
 	}
 	return nil
 }

--- a/internal/github/repos_graphql.go
+++ b/internal/github/repos_graphql.go
@@ -43,9 +43,12 @@ type orgTeamsWithReposQuery struct {
 
 // teamReposQuery is the GraphQL query struct for fetching repositories of a
 // single team. Used as a fallback when a team has more than 100 repositories.
+// Team is a pointer because organization.team(slug:) is a nullable GraphQL
+// field — the team may have been renamed or deleted between the initial
+// orgTeamsWithReposQuery page and this overflow call.
 type teamReposQuery struct {
 	Organization struct {
-		Team struct {
+		Team *struct {
 			Repositories struct {
 				PageInfo struct {
 					HasNextPage githubv4.Boolean
@@ -142,7 +145,10 @@ func (t *DefaultRepositoryProvider) buildRepoTeamsMap(ctx context.Context) (map[
 
 			// Rare edge case: team has >100 repos. Use a dedicated single-team
 			// query so the repoCursor applies only to this team.
-			if bool(team.Repositories.PageInfo.HasNextPage) {
+			// Guard against an empty EndCursor: if HasNextPage is true but
+			// EndCursor is empty the API response is malformed; skip the
+			// overflow query rather than looping on after:"".
+			if bool(team.Repositories.PageInfo.HasNextPage) && team.Repositories.PageInfo.EndCursor != "" {
 				if err := t.fetchRemainingTeamRepos(ctx, slug, team.Repositories.PageInfo.EndCursor, repoTeams); err != nil {
 					return nil, err
 				}
@@ -175,6 +181,12 @@ func (t *DefaultRepositoryProvider) fetchRemainingTeamRepos(ctx context.Context,
 			return err
 		}
 		ghmetrics.GraphQLCallsTotal.WithLabelValues(t.githubName, t.organization, "success").Inc()
+
+		// Team is nullable: the team may have been deleted/renamed between the
+		// initial teams query and this overflow call. Treat nil as an empty result.
+		if query.Organization.Team == nil {
+			break
+		}
 
 		for _, edge := range query.Organization.Team.Repositories.Edges {
 			repoName := string(edge.Node.Name)

--- a/internal/github/repos_graphql_test.go
+++ b/internal/github/repos_graphql_test.go
@@ -317,6 +317,17 @@ func TestExtendedListGraphQL_TeamsPagination(t *testing.T) {
 	if len(priv[0].Teams) != 2 {
 		t.Errorf("expected 2 teams on repo-x, got %v", priv[0].Teams)
 	}
+	// Verify exact slug names and permission mappings (order-independent).
+	bySlug := map[string]repoguardsapv1.GithubTeamPermission{}
+	for _, tp := range priv[0].Teams {
+		bySlug[tp.Team] = tp.Permission
+	}
+	if bySlug["team-a"] != "push" {
+		t.Errorf("team-a: expected push, got %q", bySlug["team-a"])
+	}
+	if bySlug["team-b"] != "pull" {
+		t.Errorf("team-b: expected pull, got %q", bySlug["team-b"])
+	}
 }
 
 // buildTeamReposGraphQLResponse builds the JSON body for a single-team repos query

--- a/internal/github/repos_graphql_test.go
+++ b/internal/github/repos_graphql_test.go
@@ -402,4 +402,15 @@ func TestExtendedListGraphQL_TeamRepoOverflow(t *testing.T) {
 			t.Errorf("repo %q: expected big-team, got %v", repo.Name, repo.Teams)
 		}
 	}
+	// Assert per-repo permissions: repo-1 from first page (WRITE→push), repo-2 from overflow (ADMIN→admin).
+	wantPerm := map[string]repoguardsapv1.GithubTeamPermission{
+		"repo-1": "push",
+		"repo-2": "admin",
+	}
+	for _, repo := range priv {
+		got := repo.Teams[0].Permission
+		if want := wantPerm[repo.Name]; got != want {
+			t.Errorf("repo %q: expected permission %q, got %q", repo.Name, want, got)
+		}
+	}
 }

--- a/internal/github/repos_graphql_test.go
+++ b/internal/github/repos_graphql_test.go
@@ -101,13 +101,15 @@ func buildRepoMetaNode(name, visibility string, archived, disabled bool) map[str
 }
 
 // buildTeamNode builds a team node with repository edges for GraphQL fixtures.
-func buildTeamNode(slug string, repoEdges []map[string]any, reposHasNextPage bool) map[string]any {
+// endCursor should be a non-empty string when reposHasNextPage is true so that
+// fetchRemainingTeamRepos receives a real cursor and pagination is exercised correctly.
+func buildTeamNode(slug string, repoEdges []map[string]any, reposHasNextPage bool, endCursor string) map[string]any {
 	return map[string]any{
 		"slug": slug,
 		"repositories": map[string]any{
 			"pageInfo": map[string]any{
 				"hasNextPage": reposHasNextPage,
-				"endCursor":   "",
+				"endCursor":   endCursor,
 			},
 			"edges": repoEdges,
 		},
@@ -147,9 +149,9 @@ func TestGraphqlPermissionToTeamPermission(t *testing.T) {
 func TestExtendedListGraphQL_Basic(t *testing.T) {
 	// Teams query: devs→pub-repo(WRITE), ops→priv-repo(ADMIN), security→int-repo(READ).
 	teamsBody := buildTeamsGraphQLResponse([]map[string]any{
-		buildTeamNode("devs", []map[string]any{buildTeamRepoEdge("pub-repo", "WRITE")}, false),
-		buildTeamNode("ops", []map[string]any{buildTeamRepoEdge("priv-repo", "ADMIN")}, false),
-		buildTeamNode("security", []map[string]any{buildTeamRepoEdge("int-repo", "READ")}, false),
+		buildTeamNode("devs", []map[string]any{buildTeamRepoEdge("pub-repo", "WRITE")}, false, ""),
+		buildTeamNode("ops", []map[string]any{buildTeamRepoEdge("priv-repo", "ADMIN")}, false, ""),
+		buildTeamNode("security", []map[string]any{buildTeamRepoEdge("int-repo", "READ")}, false, ""),
 	}, false, "")
 
 	// Repos query: three repos across all visibility buckets.
@@ -278,10 +280,10 @@ func TestExtendedListGraphQL_ArchivedFiltered(t *testing.T) {
 func TestExtendedListGraphQL_TeamsPagination(t *testing.T) {
 	// Teams query: two pages of teams. Page 1 has team-a, page 2 has team-b.
 	teamsPage1 := buildTeamsGraphQLResponse([]map[string]any{
-		buildTeamNode("team-a", []map[string]any{buildTeamRepoEdge("repo-x", "WRITE")}, false),
+		buildTeamNode("team-a", []map[string]any{buildTeamRepoEdge("repo-x", "WRITE")}, false, ""),
 	}, true, "team-cursor-1")
 	teamsPage2 := buildTeamsGraphQLResponse([]map[string]any{
-		buildTeamNode("team-b", []map[string]any{buildTeamRepoEdge("repo-x", "READ")}, false),
+		buildTeamNode("team-b", []map[string]any{buildTeamRepoEdge("repo-x", "READ")}, false, ""),
 	}, false, "")
 
 	// Repos query: single repo.
@@ -340,10 +342,11 @@ func buildTeamReposGraphQLResponse(repoEdges []map[string]any, hasNextPage bool,
 func TestExtendedListGraphQL_TeamRepoOverflow(t *testing.T) {
 	// Team "big-team" has reposHasNextPage=true in the first teams query page,
 	// triggering a dedicated teamReposQuery for the remaining repos.
+	// A real endCursor is provided so fetchRemainingTeamRepos receives it correctly.
 	teamsBody := buildTeamsGraphQLResponse([]map[string]any{
 		buildTeamNode("big-team", []map[string]any{
 			buildTeamRepoEdge("repo-1", "WRITE"),
-		}, true), // HasNextPage=true triggers fetchRemainingTeamRepos
+		}, true, "repo-cursor-overflow"), // HasNextPage=true + real cursor triggers fetchRemainingTeamRepos
 	}, false, "")
 
 	// The overflow query returns the second page of repos for big-team.

--- a/internal/github/repos_graphql_test.go
+++ b/internal/github/repos_graphql_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	gogithub "github.com/google/go-github/v88/github"
@@ -54,8 +55,25 @@ func newTestRepositoryProviderWithGraphQL(t *testing.T, graphqlHandler http.Hand
 	}
 }
 
-// buildOrgReposGraphQLResponse builds the JSON response body for a single-page
-// GraphQL query returning the given repos.
+// buildTeamsGraphQLResponse builds the JSON body for a teams-with-repos GraphQL query.
+func buildTeamsGraphQLResponse(teams []map[string]any, hasNextPage bool, endCursor string) string {
+	data := map[string]any{
+		"organization": map[string]any{
+			"teams": map[string]any{
+				"pageInfo": map[string]any{
+					"hasNextPage": hasNextPage,
+					"endCursor":   endCursor,
+				},
+				"nodes": teams,
+			},
+		},
+	}
+	b, _ := json.Marshal(graphqlResponse{Data: data})
+	return string(b)
+}
+
+// buildOrgReposGraphQLResponse builds the JSON response body for a repos-only
+// GraphQL query (no teams field).
 func buildOrgReposGraphQLResponse(nodes []map[string]any, hasNextPage bool, endCursor string) string {
 	data := map[string]any{
 		"organization": map[string]any{
@@ -72,28 +90,35 @@ func buildOrgReposGraphQLResponse(nodes []map[string]any, hasNextPage bool, endC
 	return string(b)
 }
 
-// buildRepoNode builds a single repository node for a GraphQL fixture.
-func buildRepoNode(name, visibility string, archived, disabled bool, teams []map[string]any, teamsHasNextPage bool) map[string]any {
+// buildRepoMetaNode builds a repository metadata node (no teams) for fixtures.
+func buildRepoMetaNode(name, visibility string, archived, disabled bool) map[string]any {
 	return map[string]any{
 		"name":       name,
 		"visibility": visibility,
 		"isArchived": archived,
 		"isDisabled": disabled,
-		"teams": map[string]any{
+	}
+}
+
+// buildTeamNode builds a team node with repository edges for GraphQL fixtures.
+func buildTeamNode(slug string, repoEdges []map[string]any, reposHasNextPage bool) map[string]any {
+	return map[string]any{
+		"slug": slug,
+		"repositories": map[string]any{
 			"pageInfo": map[string]any{
-				"hasNextPage": teamsHasNextPage,
+				"hasNextPage": reposHasNextPage,
 				"endCursor":   "",
 			},
-			"edges": teams,
+			"edges": repoEdges,
 		},
 	}
 }
 
-// buildTeamEdge builds a single team edge (permission + slug) for a GraphQL fixture.
-func buildTeamEdge(slug, permission string) map[string]any {
+// buildTeamRepoEdge builds a team→repo edge (permission + repo name) for GraphQL fixtures.
+func buildTeamRepoEdge(repoName, permission string) map[string]any {
 	return map[string]any{
 		"permission": permission,
-		"node":       map[string]any{"slug": slug},
+		"node":       map[string]any{"name": repoName},
 	}
 }
 
@@ -120,24 +145,30 @@ func TestGraphqlPermissionToTeamPermission(t *testing.T) {
 }
 
 func TestExtendedListGraphQL_Basic(t *testing.T) {
-	// One page, three repos across all visibility buckets.
-	nodes := []map[string]any{
-		buildRepoNode("pub-repo", "PUBLIC", false, false, []map[string]any{
-			buildTeamEdge("devs", "WRITE"),
-		}, false),
-		buildRepoNode("priv-repo", "PRIVATE", false, false, []map[string]any{
-			buildTeamEdge("ops", "ADMIN"),
-		}, false),
-		buildRepoNode("int-repo", "INTERNAL", false, false, []map[string]any{
-			buildTeamEdge("security", "READ"),
-		}, false),
-	}
-	respBody := buildOrgReposGraphQLResponse(nodes, false, "")
+	// Teams query: devs→pub-repo(WRITE), ops→priv-repo(ADMIN), security→int-repo(READ).
+	teamsBody := buildTeamsGraphQLResponse([]map[string]any{
+		buildTeamNode("devs", []map[string]any{buildTeamRepoEdge("pub-repo", "WRITE")}, false),
+		buildTeamNode("ops", []map[string]any{buildTeamRepoEdge("priv-repo", "ADMIN")}, false),
+		buildTeamNode("security", []map[string]any{buildTeamRepoEdge("int-repo", "READ")}, false),
+	}, false, "")
 
+	// Repos query: three repos across all visibility buckets.
+	reposBody := buildOrgReposGraphQLResponse([]map[string]any{
+		buildRepoMetaNode("pub-repo", "PUBLIC", false, false),
+		buildRepoMetaNode("priv-repo", "PRIVATE", false, false),
+		buildRepoMetaNode("int-repo", "INTERNAL", false, false),
+	}, false, "")
+
+	var callCount int32
 	provider := newTestRepositoryProviderWithGraphQL(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(respBody)) //nolint:errcheck
+		n := atomic.AddInt32(&callCount, 1)
+		if n == 1 {
+			w.Write([]byte(teamsBody)) //nolint:errcheck
+		} else {
+			w.Write([]byte(reposBody)) //nolint:errcheck
+		}
 	})
 
 	pub, priv, internal, err := provider.ExtendedListGraphQL(t.Context())
@@ -168,34 +199,38 @@ func TestExtendedListGraphQL_Basic(t *testing.T) {
 }
 
 func TestExtendedListGraphQL_Pagination(t *testing.T) {
-	// Two pages: first returns has_next_page=true, second returns false.
-	page1Nodes := []map[string]any{
-		buildRepoNode("repo-a", "PUBLIC", false, false, nil, false),
-	}
-	page2Nodes := []map[string]any{
-		buildRepoNode("repo-b", "PRIVATE", false, false, nil, false),
-	}
+	// Teams query returns single page (no teams for simplicity).
+	teamsBody := buildTeamsGraphQLResponse(nil, false, "")
 
-	callCount := 0
+	// Repos query: two pages.
+	page1Body := buildOrgReposGraphQLResponse([]map[string]any{
+		buildRepoMetaNode("repo-a", "PUBLIC", false, false),
+	}, true, "cursor-abc")
+	page2Body := buildOrgReposGraphQLResponse([]map[string]any{
+		buildRepoMetaNode("repo-b", "PRIVATE", false, false),
+	}, false, "")
+
+	var callCount int32
 	provider := newTestRepositoryProviderWithGraphQL(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		callCount++
-		var body string
-		if callCount == 1 {
-			body = buildOrgReposGraphQLResponse(page1Nodes, true, "cursor-abc")
-		} else {
-			body = buildOrgReposGraphQLResponse(page2Nodes, false, "")
-		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(body)) //nolint:errcheck
+		n := atomic.AddInt32(&callCount, 1)
+		switch n {
+		case 1: // teams query
+			w.Write([]byte(teamsBody)) //nolint:errcheck
+		case 2: // repos page 1
+			w.Write([]byte(page1Body)) //nolint:errcheck
+		default: // repos page 2+
+			w.Write([]byte(page2Body)) //nolint:errcheck
+		}
 	})
 
 	pub, priv, _, err := provider.ExtendedListGraphQL(t.Context())
 	if err != nil {
 		t.Fatalf("ExtendedListGraphQL: unexpected error: %v", err)
 	}
-	if callCount != 2 {
-		t.Errorf("expected 2 GraphQL calls, got %d", callCount)
+	if atomic.LoadInt32(&callCount) != 3 {
+		t.Errorf("expected 3 GraphQL calls (1 teams + 2 repos pages), got %d", callCount)
 	}
 	if len(pub) != 1 || pub[0].Name != "repo-a" {
 		t.Errorf("public repos: got %v", pub)
@@ -206,18 +241,26 @@ func TestExtendedListGraphQL_Pagination(t *testing.T) {
 }
 
 func TestExtendedListGraphQL_ArchivedFiltered(t *testing.T) {
-	// Archived and disabled repos must be excluded.
-	nodes := []map[string]any{
-		buildRepoNode("active-repo", "PUBLIC", false, false, nil, false),
-		buildRepoNode("archived-repo", "PUBLIC", true, false, nil, false),
-		buildRepoNode("disabled-repo", "PRIVATE", false, true, nil, false),
-	}
-	respBody := buildOrgReposGraphQLResponse(nodes, false, "")
+	// Teams query: no teams.
+	teamsBody := buildTeamsGraphQLResponse(nil, false, "")
 
+	// Repos query: archived and disabled repos must be excluded.
+	reposBody := buildOrgReposGraphQLResponse([]map[string]any{
+		buildRepoMetaNode("active-repo", "PUBLIC", false, false),
+		buildRepoMetaNode("archived-repo", "PUBLIC", true, false),
+		buildRepoMetaNode("disabled-repo", "PRIVATE", false, true),
+	}, false, "")
+
+	var callCount int32
 	provider := newTestRepositoryProviderWithGraphQL(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(respBody)) //nolint:errcheck
+		n := atomic.AddInt32(&callCount, 1)
+		if n == 1 {
+			w.Write([]byte(teamsBody)) //nolint:errcheck
+		} else {
+			w.Write([]byte(reposBody)) //nolint:errcheck
+		}
 	})
 
 	pub, priv, _, err := provider.ExtendedListGraphQL(t.Context())
@@ -232,67 +275,117 @@ func TestExtendedListGraphQL_ArchivedFiltered(t *testing.T) {
 	}
 }
 
-func TestExtendedListGraphQL_TeamOverflow(t *testing.T) {
-	// A repo with teamsHasNextPage=true must fall back to the REST RepositoryTeams endpoint.
-	nodes := []map[string]any{
-		buildRepoNode("overflow-repo", "PRIVATE", false, false, []map[string]any{
-			buildTeamEdge("team-gql", "READ"),
-		}, true), // HasNextPage=true triggers REST fallback
-	}
-	respBody := buildOrgReposGraphQLResponse(nodes, false, "")
+func TestExtendedListGraphQL_TeamsPagination(t *testing.T) {
+	// Teams query: two pages of teams. Page 1 has team-a, page 2 has team-b.
+	teamsPage1 := buildTeamsGraphQLResponse([]map[string]any{
+		buildTeamNode("team-a", []map[string]any{buildTeamRepoEdge("repo-x", "WRITE")}, false),
+	}, true, "team-cursor-1")
+	teamsPage2 := buildTeamsGraphQLResponse([]map[string]any{
+		buildTeamNode("team-b", []map[string]any{buildTeamRepoEdge("repo-x", "READ")}, false),
+	}, false, "")
 
-	restTeamsFixture := []map[string]any{
-		{"id": 1, "slug": "team-rest", "name": "team-rest", "permission": "push"},
-	}
+	// Repos query: single repo.
+	reposBody := buildOrgReposGraphQLResponse([]map[string]any{
+		buildRepoMetaNode("repo-x", "PRIVATE", false, false),
+	}, false, "")
 
-	callCount := 0
+	var callCount int32
 	provider := newTestRepositoryProviderWithGraphQL(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(respBody)) //nolint:errcheck
+		n := atomic.AddInt32(&callCount, 1)
+		switch n {
+		case 1:
+			w.Write([]byte(teamsPage1)) //nolint:errcheck
+		case 2:
+			w.Write([]byte(teamsPage2)) //nolint:errcheck
+		default:
+			w.Write([]byte(reposBody)) //nolint:errcheck
+		}
 	})
-
-	// Register the REST fallback handler for RepositoryTeams.
-	// We reconstruct the mux by creating a separate provider using the existing REST approach.
-	// Since newTestRepositoryProviderWithGraphQL routes / to the graphqlHandler,
-	// we need to also register REST handlers on the same mux.
-	// Instead, create a separate REST server for the fallback.
-	restMux := http.NewServeMux()
-	restSrv := httptest.NewServer(restMux)
-	t.Cleanup(restSrv.Close)
-
-	restMux.HandleFunc("/api/v3/repos/test-org/overflow-repo/teams", func(w http.ResponseWriter, r *http.Request) {
-		callCount++
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(restTeamsFixture) //nolint:errcheck
-	})
-
-	restClient, err := gogithub.NewClient(
-		gogithub.WithHTTPClient(restSrv.Client()),
-		gogithub.WithAuthToken("test-token"),
-		gogithub.WithEnterpriseURLs(restSrv.URL+"/api/v3/", restSrv.URL+"/"),
-	)
-	if err != nil {
-		t.Fatalf("create rest client: %v", err)
-	}
-	// Override the REST services on the provider.
-	provider.repositoryService = *restClient.Repositories
-	provider.teamsService = *restClient.Teams
 
 	_, priv, _, err := provider.ExtendedListGraphQL(t.Context())
 	if err != nil {
 		t.Fatalf("ExtendedListGraphQL: unexpected error: %v", err)
 	}
-
-	if callCount != 1 {
-		t.Errorf("expected 1 REST fallback call, got %d", callCount)
-	}
 	if len(priv) != 1 {
 		t.Fatalf("expected 1 private repo, got %v", priv)
 	}
-	// Teams should come from REST fallback, not GraphQL partial result.
-	if len(priv[0].Teams) != 1 || priv[0].Teams[0].Team != "team-rest" {
-		t.Errorf("expected REST-sourced team, got %v", priv[0].Teams)
+	// repo-x should have both team-a (push) and team-b (pull) permissions.
+	if len(priv[0].Teams) != 2 {
+		t.Errorf("expected 2 teams on repo-x, got %v", priv[0].Teams)
+	}
+}
+
+// buildTeamReposGraphQLResponse builds the JSON body for a single-team repos query
+// (teamReposQuery struct) used in the >100-repos overflow fallback.
+func buildTeamReposGraphQLResponse(repoEdges []map[string]any, hasNextPage bool, endCursor string) string {
+	data := map[string]any{
+		"organization": map[string]any{
+			"team": map[string]any{
+				"repositories": map[string]any{
+					"pageInfo": map[string]any{
+						"hasNextPage": hasNextPage,
+						"endCursor":   endCursor,
+					},
+					"edges": repoEdges,
+				},
+			},
+		},
+	}
+	b, _ := json.Marshal(graphqlResponse{Data: data})
+	return string(b)
+}
+
+func TestExtendedListGraphQL_TeamRepoOverflow(t *testing.T) {
+	// Team "big-team" has reposHasNextPage=true in the first teams query page,
+	// triggering a dedicated teamReposQuery for the remaining repos.
+	teamsBody := buildTeamsGraphQLResponse([]map[string]any{
+		buildTeamNode("big-team", []map[string]any{
+			buildTeamRepoEdge("repo-1", "WRITE"),
+		}, true), // HasNextPage=true triggers fetchRemainingTeamRepos
+	}, false, "")
+
+	// The overflow query returns the second page of repos for big-team.
+	overflowBody := buildTeamReposGraphQLResponse([]map[string]any{
+		buildTeamRepoEdge("repo-2", "ADMIN"),
+	}, false, "")
+
+	// Repos metadata query.
+	reposBody := buildOrgReposGraphQLResponse([]map[string]any{
+		buildRepoMetaNode("repo-1", "PRIVATE", false, false),
+		buildRepoMetaNode("repo-2", "PRIVATE", false, false),
+	}, false, "")
+
+	var callCount int32
+	provider := newTestRepositoryProviderWithGraphQL(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		n := atomic.AddInt32(&callCount, 1)
+		switch n {
+		case 1: // teams query
+			w.Write([]byte(teamsBody)) //nolint:errcheck
+		case 2: // overflow single-team query
+			w.Write([]byte(overflowBody)) //nolint:errcheck
+		default: // repos metadata query
+			w.Write([]byte(reposBody)) //nolint:errcheck
+		}
+	})
+
+	_, priv, _, err := provider.ExtendedListGraphQL(t.Context())
+	if err != nil {
+		t.Fatalf("ExtendedListGraphQL: unexpected error: %v", err)
+	}
+	if atomic.LoadInt32(&callCount) != 3 {
+		t.Errorf("expected 3 GraphQL calls (teams + overflow + repos), got %d", callCount)
+	}
+	if len(priv) != 2 {
+		t.Fatalf("expected 2 private repos, got %v", priv)
+	}
+	// Both repos should be associated with big-team.
+	for _, repo := range priv {
+		if len(repo.Teams) != 1 || repo.Teams[0].Team != "big-team" {
+			t.Errorf("repo %q: expected big-team, got %v", repo.Name, repo.Teams)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- GitHub's GraphQL API does not expose a `teams` field on the `Repository` type, causing every `GithubOrganization` reconcile to fail with `Field 'teams' doesn't exist on type 'Repository'` (root cause of the nightly failures in run [#28521420326](https://github.com/cloudoperators/repo-guard/actions/runs/28521420326/job/84546321018))
- Rewrites `ExtendedListGraphQL` to traverse the graph in the correct direction: `organisation → teams → repositories`, building a `repoName → []teams` map first, then fetching repo metadata separately and combining
- For the rare edge case of a team with >100 repositories, a dedicated `teamReposQuery` paginates that team's repos in isolation (avoids the cursor-scope bug of the previous approach)

## Test plan

- [ ] All existing unit tests updated to match the new two-query pattern and pass (`go test ./internal/github/`)
- [ ] `TestExtendedListGraphQL_TeamsPagination` — verifies multiple pages of teams are merged correctly
- [ ] `TestExtendedListGraphQL_TeamRepoOverflow` — verifies the >100-repos single-team fallback query
- [ ] Nightly triggered on this branch: [run #28525623010](https://github.com/cloudoperators/repo-guard/actions/runs/28525623010)