### PR TITLE
fix(github): handle 422 suspended users as terminal failed state

### DIFF
--- a/api/v1/githubteam_types.go
+++ b/api/v1/githubteam_types.go
@@ -145,9 +145,8 @@ func (github GithubTeam) ChangeCalculator(desiredMembers []Member) (bool, *Githu
 	// Process desired members to identify additions
 	for _, desiredMember := range desiredMembers {
 		lowerGithubUsername := strings.ToLower(desiredMember.GithubUsername)
-		// Skip users marked as NotFound or Failed (terminal states — no retry)
-		if userOpStateMap[lowerGithubUsername] == GithubUserOperationStateNotFound ||
-			userOpStateMap[lowerGithubUsername] == GithubUserOperationStateFailed {
+		// Skip users marked as NotFound (terminal state — no retry)
+		if userOpStateMap[lowerGithubUsername] == GithubUserOperationStateNotFound {
 			continue
 		}
 
@@ -160,7 +159,6 @@ func (github GithubTeam) ChangeCalculator(desiredMembers []Member) (bool, *Githu
 					(op.State == GithubUserOperationStatePending ||
 						op.State == GithubUserOperationStateComplete ||
 						op.State == GithubUserOperationStateSkipped ||
-						op.State == GithubUserOperationStateFailed ||
 						op.State == GithubUserOperationStateNotFound) {
 					operationExists = true
 					break

--- a/api/v1/githubteam_types.go
+++ b/api/v1/githubteam_types.go
@@ -145,8 +145,9 @@ func (github GithubTeam) ChangeCalculator(desiredMembers []Member) (bool, *Githu
 	// Process desired members to identify additions
 	for _, desiredMember := range desiredMembers {
 		lowerGithubUsername := strings.ToLower(desiredMember.GithubUsername)
-		// Skip users marked as NotFound
-		if userOpStateMap[lowerGithubUsername] == GithubUserOperationStateNotFound {
+		// Skip users marked as NotFound or Failed (terminal states — no retry)
+		if userOpStateMap[lowerGithubUsername] == GithubUserOperationStateNotFound ||
+			userOpStateMap[lowerGithubUsername] == GithubUserOperationStateFailed {
 			continue
 		}
 
@@ -159,6 +160,7 @@ func (github GithubTeam) ChangeCalculator(desiredMembers []Member) (bool, *Githu
 					(op.State == GithubUserOperationStatePending ||
 						op.State == GithubUserOperationStateComplete ||
 						op.State == GithubUserOperationStateSkipped ||
+						op.State == GithubUserOperationStateFailed ||
 						op.State == GithubUserOperationStateNotFound) {
 					operationExists = true
 					break

--- a/api/v1/githubteam_types_test.go
+++ b/api/v1/githubteam_types_test.go
@@ -32,16 +32,17 @@ func TestGithubTeamChangeCalculator(t *testing.T) {
 			wantOpsLen:      0,
 		},
 		{
-			name: "desired member has existing failed add op — skipped, no new op",
+			name: "desired member has existing failed add op — retryable, new pending op queued",
 			existingOps: []GithubUserOperation{
 				{User: "bob", Operation: GithubUserOperationTypeAdd, State: GithubUserOperationStateFailed},
 			},
 			desiredMembers: []Member{{GithubUsername: "bob"}},
-			wantChanged:    false,
-			wantOpsLen:     1, // existing op preserved, no new one added
+			wantChanged:    true,
+			wantOpsLen:     2, // existing failed op preserved + new pending op added
+			wantAddUsers:   []string{"bob"},
 		},
 		{
-			name: "desired member has existing notfound add op — skipped, no new op",
+			name: "desired member has existing notfound add op — terminal, no new op",
 			existingOps: []GithubUserOperation{
 				{User: "carol", Operation: GithubUserOperationTypeAdd, State: GithubUserOperationStateNotFound},
 			},
@@ -59,9 +60,9 @@ func TestGithubTeamChangeCalculator(t *testing.T) {
 			wantOpsLen:     1,
 		},
 		{
-			name: "case-insensitive: failed op stored as uppercase — still skipped",
+			name: "case-insensitive: notfound op stored as uppercase — still skipped",
 			existingOps: []GithubUserOperation{
-				{User: "Eve", Operation: GithubUserOperationTypeAdd, State: GithubUserOperationStateFailed},
+				{User: "Eve", Operation: GithubUserOperationTypeAdd, State: GithubUserOperationStateNotFound},
 			},
 			desiredMembers: []Member{{GithubUsername: "eve"}},
 			wantChanged:    false,
@@ -75,16 +76,16 @@ func TestGithubTeamChangeCalculator(t *testing.T) {
 			wantOpsLen:      1,
 		},
 		{
-			name: "multiple desired: one failed, one new — only new gets add op",
+			name: "multiple desired: one notfound (terminal), one new — only new gets add op",
 			existingOps: []GithubUserOperation{
-				{User: "grace", Operation: GithubUserOperationTypeAdd, State: GithubUserOperationStateFailed},
+				{User: "grace", Operation: GithubUserOperationTypeAdd, State: GithubUserOperationStateNotFound},
 			},
 			desiredMembers: []Member{
 				{GithubUsername: "grace"},
 				{GithubUsername: "henry"},
 			},
 			wantChanged:  true,
-			wantOpsLen:   2, // grace's failed op + henry's new pending op
+			wantOpsLen:   2, // grace's notfound op + henry's new pending op
 			wantAddUsers: []string{"henry"},
 		},
 	}

--- a/api/v1/githubteam_types_test.go
+++ b/api/v1/githubteam_types_test.go
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"testing"
+)
+
+func TestGithubTeamChangeCalculator(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingMembers []Member
+		existingOps     []GithubUserOperation
+		desiredMembers  []Member
+		wantChanged     bool
+		wantOpsLen      int
+		wantAddUsers    []string
+	}{
+		{
+			name:           "desired member not yet present — add op queued",
+			desiredMembers: []Member{{GithubUsername: "alice"}},
+			wantChanged:    true,
+			wantOpsLen:     1,
+			wantAddUsers:   []string{"alice"},
+		},
+		{
+			name:            "desired member already in status.Members — no new op",
+			existingMembers: []Member{{GithubUsername: "alice"}},
+			desiredMembers:  []Member{{GithubUsername: "alice"}},
+			wantChanged:     false,
+			wantOpsLen:      0,
+		},
+		{
+			name: "desired member has existing failed add op — skipped, no new op",
+			existingOps: []GithubUserOperation{
+				{User: "bob", Operation: GithubUserOperationTypeAdd, State: GithubUserOperationStateFailed},
+			},
+			desiredMembers: []Member{{GithubUsername: "bob"}},
+			wantChanged:    false,
+			wantOpsLen:     1, // existing op preserved, no new one added
+		},
+		{
+			name: "desired member has existing notfound add op — skipped, no new op",
+			existingOps: []GithubUserOperation{
+				{User: "carol", Operation: GithubUserOperationTypeAdd, State: GithubUserOperationStateNotFound},
+			},
+			desiredMembers: []Member{{GithubUsername: "carol"}},
+			wantChanged:    false,
+			wantOpsLen:     1,
+		},
+		{
+			name: "desired member has existing pending add op — no duplicate",
+			existingOps: []GithubUserOperation{
+				{User: "dave", Operation: GithubUserOperationTypeAdd, State: GithubUserOperationStatePending},
+			},
+			desiredMembers: []Member{{GithubUsername: "dave"}},
+			wantChanged:    false,
+			wantOpsLen:     1,
+		},
+		{
+			name: "case-insensitive: failed op stored as uppercase — still skipped",
+			existingOps: []GithubUserOperation{
+				{User: "Eve", Operation: GithubUserOperationTypeAdd, State: GithubUserOperationStateFailed},
+			},
+			desiredMembers: []Member{{GithubUsername: "eve"}},
+			wantChanged:    false,
+			wantOpsLen:     1,
+		},
+		{
+			name:            "current member not in desired — remove op queued",
+			existingMembers: []Member{{GithubUsername: "frank"}},
+			desiredMembers:  []Member{},
+			wantChanged:     true,
+			wantOpsLen:      1,
+		},
+		{
+			name: "multiple desired: one failed, one new — only new gets add op",
+			existingOps: []GithubUserOperation{
+				{User: "grace", Operation: GithubUserOperationTypeAdd, State: GithubUserOperationStateFailed},
+			},
+			desiredMembers: []Member{
+				{GithubUsername: "grace"},
+				{GithubUsername: "henry"},
+			},
+			wantChanged:  true,
+			wantOpsLen:   2, // grace's failed op + henry's new pending op
+			wantAddUsers: []string{"henry"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			team := GithubTeam{}
+			team.Status.Members = tt.existingMembers
+			team.Status.Operations = tt.existingOps
+
+			changed, newStatus := team.ChangeCalculator(tt.desiredMembers)
+
+			if changed != tt.wantChanged {
+				t.Errorf("changed = %v, want %v", changed, tt.wantChanged)
+			}
+			if len(newStatus.Operations) != tt.wantOpsLen {
+				t.Errorf("ops len = %d, want %d; ops = %v", len(newStatus.Operations), tt.wantOpsLen, newStatus.Operations)
+			}
+			for _, wantUser := range tt.wantAddUsers {
+				found := false
+				for _, op := range newStatus.Operations {
+					if op.User == wantUser && op.Operation == GithubUserOperationTypeAdd && op.State == GithubUserOperationStatePending {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected pending add op for user %q, not found in ops: %v", wantUser, newStatus.Operations)
+				}
+			}
+		})
+	}
+}

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -1068,12 +1068,12 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					} else {
 						userFound, err := teamsProvider.AddUser(ctx, githubTeamName, userOperation.User)
 						if !userFound {
-							l.Info("user not found on GitHub: marking operation as notfound", "user", userOperation.User)
-							newStatus.Operations[i].State = v1.GithubUserOperationStateNotFound
-							newStatus.Operations[i].Error = "user not found on GitHub"
+							l.Info("user cannot be added to team: marking operation as failed", "user", userOperation.User, "error", err)
+							newStatus.Operations[i].State = v1.GithubUserOperationStateFailed
+							newStatus.Operations[i].Error = err.Error()
 							newStatus.Operations[i].Timestamp = metav1.Now()
 							statusChanged = true
-							// Don't set 'failed' to true because this is a terminal state
+							// Don't set 'failed' to true — this is a terminal state, no retry
 						} else if err != nil {
 							l.Error(err, "error during adding user to the team", "user", userOperation.User, "team", githubTeamName)
 							newStatus.Operations[i].State = v1.GithubUserOperationStateFailed

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -1068,8 +1068,8 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					} else {
 						userFound, err := teamsProvider.AddUser(ctx, githubTeamName, userOperation.User)
 						if !userFound {
-							l.Info("user cannot be added to team: marking operation as failed", "user", userOperation.User, "error", err)
-							newStatus.Operations[i].State = v1.GithubUserOperationStateFailed
+							l.Info("user cannot be added to team: marking operation as notfound", "user", userOperation.User, "error", err)
+							newStatus.Operations[i].State = v1.GithubUserOperationStateNotFound
 							newStatus.Operations[i].Error = err.Error()
 							newStatus.Operations[i].Timestamp = metav1.Now()
 							statusChanged = true

--- a/internal/github/teams.go
+++ b/internal/github/teams.go
@@ -273,6 +273,9 @@ func (t DefaultTeamsProvider) AddUser(ctx context.Context, team, user string) (b
 			if response.StatusCode == 404 {
 				return false, fmt.Errorf("user not found in github")
 			}
+			if response.StatusCode == 422 {
+				return false, fmt.Errorf("user is suspended or unprocessable in github")
+			}
 			if response.StatusCode != 200 {
 				return true, fmt.Errorf("adding user to team response code: %d", response.StatusCode)
 			}

--- a/internal/github/teams.go
+++ b/internal/github/teams.go
@@ -271,7 +271,7 @@ func (t DefaultTeamsProvider) AddUser(ctx context.Context, team, user string) (b
 	if err != nil {
 		if response != nil {
 			if response.StatusCode == 404 {
-				return false, fmt.Errorf("user not found in github")
+				return false, fmt.Errorf("user not found in github: %w", err)
 			}
 			if response.StatusCode == 422 {
 				return false, fmt.Errorf("user is suspended or unprocessable in github: %w", err)

--- a/internal/github/teams.go
+++ b/internal/github/teams.go
@@ -274,7 +274,7 @@ func (t DefaultTeamsProvider) AddUser(ctx context.Context, team, user string) (b
 				return false, fmt.Errorf("user not found in github")
 			}
 			if response.StatusCode == 422 {
-				return false, fmt.Errorf("user is suspended or unprocessable in github")
+				return false, fmt.Errorf("user is suspended or unprocessable in github: %w", err)
 			}
 			if response.StatusCode != 200 {
 				return true, fmt.Errorf("adding user to team response code: %d", response.StatusCode)

--- a/internal/github/teams_test.go
+++ b/internal/github/teams_test.go
@@ -7,10 +7,83 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	gogithub "github.com/google/go-github/v88/github"
 )
+
+func TestTeamsProvider_AddUser(t *testing.T) {
+	cases := []struct {
+		name            string
+		statusCode      int
+		wantFound       bool
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name:       "success — 200 returns found=true, no error",
+			statusCode: http.StatusOK,
+			wantFound:  true,
+			wantErr:    false,
+		},
+		{
+			name:            "404 — user not found returns found=false",
+			statusCode:      http.StatusNotFound,
+			wantFound:       false,
+			wantErr:         true,
+			wantErrContains: "user not found",
+		},
+		{
+			name:            "422 — suspended user returns found=false",
+			statusCode:      http.StatusUnprocessableEntity,
+			wantFound:       false,
+			wantErr:         true,
+			wantErrContains: "suspended",
+		},
+		{
+			name:            "500 — server error returns found=true with error",
+			statusCode:      http.StatusInternalServerError,
+			wantFound:       true,
+			wantErr:         true,
+			wantErrContains: "500",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider, mux := newTestTeamsProvider(t)
+
+			mux.HandleFunc("/api/v3/orgs/test-org/teams/my-team/memberships/alice",
+				func(w http.ResponseWriter, r *http.Request) {
+					if tc.statusCode == http.StatusOK {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(tc.statusCode)
+						_ = json.NewEncoder(w).Encode(map[string]any{"state": "pending", "role": "member"})
+					} else {
+						http.Error(w, http.StatusText(tc.statusCode), tc.statusCode)
+					}
+				})
+
+			found, err := provider.AddUser(t.Context(), "my-team", "alice")
+
+			if found != tc.wantFound {
+				t.Errorf("found: got %v, want %v", found, tc.wantFound)
+			}
+			if tc.wantErr && err == nil {
+				t.Error("expected an error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tc.wantErrContains != "" && err != nil {
+				if !strings.Contains(err.Error(), tc.wantErrContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.wantErrContains)
+				}
+			}
+		})
+	}
+}
 
 // newTestTeamsProvider creates a DefaultTeamsProvider backed by a fake HTTP server.
 func newTestTeamsProvider(t *testing.T) (*DefaultTeamsProvider, *http.ServeMux) {

--- a/internal/github/teams_test.go
+++ b/internal/github/teams_test.go
@@ -28,6 +28,12 @@ func TestTeamsProvider_AddUser(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name:       "success — 201 (membership created) returns found=true, no error",
+			statusCode: http.StatusCreated,
+			wantFound:  true,
+			wantErr:    false,
+		},
+		{
 			name:            "404 — user not found returns found=false",
 			statusCode:      http.StatusNotFound,
 			wantFound:       false,
@@ -56,7 +62,7 @@ func TestTeamsProvider_AddUser(t *testing.T) {
 
 			mux.HandleFunc("/api/v3/orgs/test-org/teams/my-team/memberships/alice",
 				func(w http.ResponseWriter, r *http.Request) {
-					if tc.statusCode == http.StatusOK {
+					if tc.statusCode == http.StatusOK || tc.statusCode == http.StatusCreated {
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(tc.statusCode)
 						_ = json.NewEncoder(w).Encode(map[string]any{"state": "pending", "role": "member"})


### PR DESCRIPTION
## Summary

- `AddUser` now returns `(false, err)` for HTTP 422 (suspended/unprocessable user) and HTTP 404 (user not found), matching the existing terminal semantics — both signal a non-retryable condition; the original error is wrapped for diagnostics
- Controller marks operations where `userFound=false` as `StateNotFound` (terminal) with the actual error message, instead of the previous hardcoded string; `StateFailed` remains reserved for retryable transient errors (e.g. HTTP 500)
- `ChangeCalculator` continues to skip only `StateNotFound` operations, keeping `StateFailed` ops retryable — the controller will re-queue a pending add op after a transient failure

## Problem

GitHub returns 422 when trying to add a suspended org member to a team. The previous code only special-cased 404; a 422 fell through as a retryable error (`StateFailed`), so the controller would loop indefinitely. Additionally, the error message for 404/422 was hardcoded, losing the original go-github diagnostic details.

## Test plan

- [x] `TestTeamsProvider_AddUser` — unit tests for 200 / 404 / 422 / 500 HTTP responses, verifying `(found, err)` return values
- [x] `TestGithubTeamChangeCalculator` — 8 cases covering notfound terminal skip, failed retryable, deduplication, case-insensitivity, add/remove operations
- [x] `make controller-test` — all 31 integration tests pass
- [x] `make lint` — 0 issues