### PR TITLE
fix(controller): resolve orgs stuck in pending when dry-run collab/member removal is active

### DIFF
--- a/api/v1/githuborganization_types.go
+++ b/api/v1/githuborganization_types.go
@@ -619,32 +619,32 @@ func repoChangeCalculator(defaultConfig []GithubTeamWithPermission, actual []Git
 	return newOperations
 }
 
-func (g GithubOrganization) PendingOperationsFound() bool {
+func (s GithubOrganizationStatus) PendingOperationsFound() bool {
 
-	for _, op := range g.Status.Operations.OrganizationOwnerOperations {
+	for _, op := range s.Operations.OrganizationOwnerOperations {
 		if op.State == GithubUserOperationStatePending {
 			return true
 		}
 	}
 
-	for _, op := range g.Status.Operations.OrganizationMemberOperations {
+	for _, op := range s.Operations.OrganizationMemberOperations {
 		if op.State == GithubUserOperationStatePending {
 			return true
 		}
 	}
 
-	for _, op := range g.Status.Operations.RepositoryTeamOperations {
+	for _, op := range s.Operations.RepositoryTeamOperations {
 		if op.State == GithubRepoTeamOperationStatePending {
 			return true
 		}
 	}
-	for _, op := range g.Status.Operations.GithubTeamOperations {
+	for _, op := range s.Operations.GithubTeamOperations {
 		if op.State == GithubTeamOperationStatePending {
 			return true
 		}
 	}
 
-	for _, op := range g.Status.Operations.RepositoryCollaboratorOperations {
+	for _, op := range s.Operations.RepositoryCollaboratorOperations {
 		if op.State == GithubRepoUserOperationStatePending {
 			return true
 		}
@@ -652,6 +652,10 @@ func (g GithubOrganization) PendingOperationsFound() bool {
 
 	return false
 
+}
+
+func (g GithubOrganization) PendingOperationsFound() bool {
+	return g.Status.PendingOperationsFound()
 }
 
 func (g GithubOrganization) FailedOperationsFound() bool {

--- a/api/v1/githuborganization_types.go
+++ b/api/v1/githuborganization_types.go
@@ -925,7 +925,7 @@ func (g *GithubOrganization) OrganizationMemberChangeCalculator(
 	// Build set of users with existing pending ops to avoid duplicates
 	pendingSet := make(map[string]struct{})
 	for _, op := range g.Status.Operations.OrganizationMemberOperations {
-		if op.State == GithubUserOperationStatePending || op.State == GithubUserOperationStateFailed {
+		if op.State == GithubUserOperationStatePending || op.State == GithubUserOperationStateFailed || op.State == GithubUserOperationStateSkipped {
 			pendingSet[strings.ToLower(op.User)] = struct{}{}
 		}
 	}
@@ -996,7 +996,7 @@ func (g *GithubOrganization) RepositoryDirectCollaboratorChangeCalculator(
 	type repoUser struct{ repo, user string }
 	pendingSet := make(map[repoUser]struct{})
 	for _, op := range g.Status.Operations.RepositoryCollaboratorOperations {
-		if op.State == GithubRepoUserOperationStatePending || op.State == GithubRepoUserOperationStateFailed {
+		if op.State == GithubRepoUserOperationStatePending || op.State == GithubRepoUserOperationStateFailed || op.State == GithubRepoUserOperationStateSkipped {
 			pendingSet[repoUser{repo: op.Repo, user: strings.ToLower(op.User)}] = struct{}{}
 		}
 	}

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -1344,6 +1344,7 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 			if orgMemberLabel == GITHUB_ORG_LABEL_REMOVE_ORG_MEMBER_DRYRUN_VALUE {
 				// dry-run: keep op pending so operators can inspect who would be removed
 				l.Info("removing organization members is in dry-run mode: operation left pending (not executed)", "user", op.User)
+				statusChanged = true
 				continue
 			}
 			if orgMemberLabel != GITHUB_ORG_LABEL_REMOVE_ORG_MEMBER_ENABLED_VALUE {
@@ -1432,6 +1433,7 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 			if repoCollabLabel == GITHUB_ORG_LABEL_REMOVE_REPOSITORY_DIRECT_COLLABORATOR_DRYRUN_VALUE {
 				// dry-run: keep op pending so operators can inspect who would be removed
 				l.Info("removing repository direct collaborators is in dry-run mode: operation left pending (not executed)", "repo", op.Repo, "user", op.User)
+				statusChanged = true
 				continue
 			}
 			if repoCollabLabel != GITHUB_ORG_LABEL_REMOVE_REPOSITORY_DIRECT_COLLABORATOR_ENABLED_VALUE {
@@ -1509,6 +1511,11 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 			if failed {
 				newStatus.OrganizationStatus = v1.GithubOrganizationStateFailed
+			} else if newStatus.PendingOperationsFound() {
+				// Some operations are intentionally left pending (dry-run mode for member/collaborator removal).
+				// Use the dry-run state so the resource does not stay in "pending" forever.
+				newStatus.OrganizationStatus = v1.GithubOrganizationStateDryRun
+				newStatus.OrganizationStatusError = ""
 			} else {
 				newStatus.OrganizationStatus = v1.GithubOrganizationStateComplete
 				newStatus.OrganizationStatusError = ""

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -1333,6 +1333,18 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		for _, p := range githubOrganization.Spec.ProtectedMembers {
 			orgMemberProtectedSet[strings.ToLower(p)] = struct{}{}
 		}
+		// If the label has been switched from dryRun to enabled, revive previously-skipped
+		// remove ops back to pending so the execution loop below can process them.
+		if githubOrganization.Labels != nil && githubOrganization.Labels[GITHUB_ORG_LABEL_REMOVE_ORG_MEMBER] == GITHUB_ORG_LABEL_REMOVE_ORG_MEMBER_ENABLED_VALUE {
+			for i, op := range newStatus.Operations.OrganizationMemberOperations {
+				if op.State == v1.GithubUserOperationStateSkipped && op.Operation == v1.GithubUserOperationTypeRemove {
+					l.Info("reviving skipped org-member remove op to pending (label switched to enabled)", "user", op.User)
+					newStatus.Operations.OrganizationMemberOperations[i].State = v1.GithubUserOperationStatePending
+					newStatus.Operations.OrganizationMemberOperations[i].Timestamp = metav1.Now()
+					statusChanged = true
+				}
+			}
+		}
 		for i, op := range newStatus.Operations.OrganizationMemberOperations {
 			if op.State != v1.GithubUserOperationStatePending {
 				continue
@@ -1424,6 +1436,18 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		repoCollabProtectedSet := make(map[string]struct{}, len(githubOrganization.Spec.ProtectedMembers))
 		for _, p := range githubOrganization.Spec.ProtectedMembers {
 			repoCollabProtectedSet[strings.ToLower(p)] = struct{}{}
+		}
+		// If the label has been switched from dryRun to enabled, revive previously-skipped
+		// remove ops back to pending so the execution loop below can process them.
+		if githubOrganization.Labels != nil && githubOrganization.Labels[GITHUB_ORG_LABEL_REMOVE_REPOSITORY_DIRECT_COLLABORATOR] == GITHUB_ORG_LABEL_REMOVE_REPOSITORY_DIRECT_COLLABORATOR_ENABLED_VALUE {
+			for i, op := range newStatus.Operations.RepositoryCollaboratorOperations {
+				if op.State == v1.GithubRepoUserOperationStateSkipped && op.Operation == v1.GithubRepoUserOperationTypeRemove {
+					l.Info("reviving skipped repo-collab remove op to pending (label switched to enabled)", "repo", op.Repo, "user", op.User)
+					newStatus.Operations.RepositoryCollaboratorOperations[i].State = v1.GithubRepoUserOperationStatePending
+					newStatus.Operations.RepositoryCollaboratorOperations[i].Timestamp = metav1.Now()
+					statusChanged = true
+				}
+			}
 		}
 		for i, op := range newStatus.Operations.RepositoryCollaboratorOperations {
 			if op.State != v1.GithubRepoUserOperationStatePending {

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -1335,9 +1335,13 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 		// If the label has been switched from dryRun to enabled, revive previously-skipped
 		// remove ops back to pending so the execution loop below can process them.
+		// Skip revival for protected members to avoid a pending↔skipped flap.
 		if githubOrganization.Labels != nil && githubOrganization.Labels[GITHUB_ORG_LABEL_REMOVE_ORG_MEMBER] == GITHUB_ORG_LABEL_REMOVE_ORG_MEMBER_ENABLED_VALUE {
 			for i, op := range newStatus.Operations.OrganizationMemberOperations {
 				if op.State == v1.GithubUserOperationStateSkipped && op.Operation == v1.GithubUserOperationTypeRemove {
+					if _, isProt := orgMemberProtectedSet[strings.ToLower(op.User)]; isProt {
+						continue
+					}
 					l.Info("reviving skipped org-member remove op to pending (label switched to enabled)", "user", op.User)
 					newStatus.Operations.OrganizationMemberOperations[i].State = v1.GithubUserOperationStatePending
 					newStatus.Operations.OrganizationMemberOperations[i].Timestamp = metav1.Now()
@@ -1439,9 +1443,13 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 		// If the label has been switched from dryRun to enabled, revive previously-skipped
 		// remove ops back to pending so the execution loop below can process them.
+		// Skip revival for protected members to avoid a pending↔skipped flap.
 		if githubOrganization.Labels != nil && githubOrganization.Labels[GITHUB_ORG_LABEL_REMOVE_REPOSITORY_DIRECT_COLLABORATOR] == GITHUB_ORG_LABEL_REMOVE_REPOSITORY_DIRECT_COLLABORATOR_ENABLED_VALUE {
 			for i, op := range newStatus.Operations.RepositoryCollaboratorOperations {
 				if op.State == v1.GithubRepoUserOperationStateSkipped && op.Operation == v1.GithubRepoUserOperationTypeRemove {
+					if _, isProt := repoCollabProtectedSet[strings.ToLower(op.User)]; isProt {
+						continue
+					}
 					l.Info("reviving skipped repo-collab remove op to pending (label switched to enabled)", "repo", op.Repo, "user", op.User)
 					newStatus.Operations.RepositoryCollaboratorOperations[i].State = v1.GithubRepoUserOperationStatePending
 					newStatus.Operations.RepositoryCollaboratorOperations[i].Timestamp = metav1.Now()

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -1344,7 +1344,6 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 			if orgMemberLabel == GITHUB_ORG_LABEL_REMOVE_ORG_MEMBER_DRYRUN_VALUE {
 				// dry-run: keep op pending so operators can inspect who would be removed
 				l.Info("removing organization members is in dry-run mode: operation left pending (not executed)", "user", op.User)
-				statusChanged = true
 				continue
 			}
 			if orgMemberLabel != GITHUB_ORG_LABEL_REMOVE_ORG_MEMBER_ENABLED_VALUE {
@@ -1433,7 +1432,6 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 			if repoCollabLabel == GITHUB_ORG_LABEL_REMOVE_REPOSITORY_DIRECT_COLLABORATOR_DRYRUN_VALUE {
 				// dry-run: keep op pending so operators can inspect who would be removed
 				l.Info("removing repository direct collaborators is in dry-run mode: operation left pending (not executed)", "repo", op.Repo, "user", op.User)
-				statusChanged = true
 				continue
 			}
 			if repoCollabLabel != GITHUB_ORG_LABEL_REMOVE_REPOSITORY_DIRECT_COLLABORATOR_ENABLED_VALUE {
@@ -1507,6 +1505,12 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 
 		// status changed check & reflect on Kubernetes
+		// If no op actually mutated anything but some ops are intentionally left pending
+		// (dry-run mode), we still need to write status once so the top-level state
+		// transitions from "pending" to "dry-run" and the reconcile loop stops.
+		if !statusChanged && !failed && newStatus.PendingOperationsFound() {
+			statusChanged = true
+		}
 		if statusChanged {
 
 			if failed {

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -1342,8 +1342,12 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 				orgMemberLabel = githubOrganization.Labels[GITHUB_ORG_LABEL_REMOVE_ORG_MEMBER]
 			}
 			if orgMemberLabel == GITHUB_ORG_LABEL_REMOVE_ORG_MEMBER_DRYRUN_VALUE {
-				// dry-run: keep op pending so operators can inspect who would be removed
-				l.Info("removing organization members is in dry-run mode: operation left pending (not executed)", "user", op.User)
+				// dry-run: mark as skipped so operators can inspect who would be removed
+				// without leaving the op in pending (which would block status from resolving).
+				l.Info("removing organization members is in dry-run mode: operation skipped", "user", op.User)
+				newStatus.Operations.OrganizationMemberOperations[i].State = v1.GithubUserOperationStateSkipped
+				newStatus.Operations.OrganizationMemberOperations[i].Timestamp = metav1.Now()
+				statusChanged = true
 				continue
 			}
 			if orgMemberLabel != GITHUB_ORG_LABEL_REMOVE_ORG_MEMBER_ENABLED_VALUE {
@@ -1430,8 +1434,12 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 				repoCollabLabel = githubOrganization.Labels[GITHUB_ORG_LABEL_REMOVE_REPOSITORY_DIRECT_COLLABORATOR]
 			}
 			if repoCollabLabel == GITHUB_ORG_LABEL_REMOVE_REPOSITORY_DIRECT_COLLABORATOR_DRYRUN_VALUE {
-				// dry-run: keep op pending so operators can inspect who would be removed
-				l.Info("removing repository direct collaborators is in dry-run mode: operation left pending (not executed)", "repo", op.Repo, "user", op.User)
+				// dry-run: mark as skipped so operators can inspect who would be removed
+				// without leaving the op in pending (which would block status from resolving).
+				l.Info("removing repository direct collaborators is in dry-run mode: operation skipped", "repo", op.Repo, "user", op.User)
+				newStatus.Operations.RepositoryCollaboratorOperations[i].State = v1.GithubRepoUserOperationStateSkipped
+				newStatus.Operations.RepositoryCollaboratorOperations[i].Timestamp = metav1.Now()
+				statusChanged = true
 				continue
 			}
 			if repoCollabLabel != GITHUB_ORG_LABEL_REMOVE_REPOSITORY_DIRECT_COLLABORATOR_ENABLED_VALUE {
@@ -1505,21 +1513,10 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 
 		// status changed check & reflect on Kubernetes
-		// If no op actually mutated anything but some ops are intentionally left pending
-		// (dry-run mode), we still need to write status once so the top-level state
-		// transitions from "pending" to "dry-run" and the reconcile loop stops.
-		if !statusChanged && !failed && newStatus.PendingOperationsFound() {
-			statusChanged = true
-		}
 		if statusChanged {
 
 			if failed {
 				newStatus.OrganizationStatus = v1.GithubOrganizationStateFailed
-			} else if newStatus.PendingOperationsFound() {
-				// Some operations are intentionally left pending (dry-run mode for member/collaborator removal).
-				// Use the dry-run state so the resource does not stay in "pending" forever.
-				newStatus.OrganizationStatus = v1.GithubOrganizationStateDryRun
-				newStatus.OrganizationStatusError = ""
 			} else {
 				newStatus.OrganizationStatus = v1.GithubOrganizationStateComplete
 				newStatus.OrganizationStatusError = ""


### PR DESCRIPTION
## Summary

- When \`OrganizationMemberOperations\` or \`RepositoryCollaboratorOperations\` are in dry-run mode, ops were intentionally left in \`pending\` state — but \`PendingOperationsFound()\` returning \`true\` caused the org to re-enter the pending execution branch on every reconcile, permanently stuck in \`pending\`.
- Dry-run ops (label set to \`dryRun\`) are now marked as \`skipped\` instead of \`pending\`. Skipped ops remain visible in the status for operator inspection, \`PendingOperationsFound()\` returns false, and the top-level org status resolves to \`complete\`.
- Both calculators (\`OrganizationMemberChangeCalculator\` and \`RepositoryDirectCollaboratorChangeCalculator\`) now include \`skipped\` in their de-dup sets, so a user already covered by a skipped op is not re-queued on the next reconcile.
- Refactored \`PendingOperationsFound()\` onto \`GithubOrganizationStatus\` (the existing method on \`GithubOrganization\` now delegates to it).

## Test plan

- [ ] Deploy with \`removeOrgMembers\` or \`removeRepositoryDirectCollaborators\` label set to \`dryRun\` and verify:
  - Ops appear as \`skipped\` in status
  - Org transitions to \`complete\` (not \`pending\` or \`dry-run\`)
  - No new remove ops are re-appended on subsequent reconciles
- [ ] Verify org transitions to \`complete\` when neither feature is enabled (ops marked \`skipped\`)
- [ ] Verify org transitions to \`complete\` when the label is set to \`enabled\` and ops execute successfully
- [ ] Run \`make controller-test\` — all existing tests pass