### PR TITLE
fix(controller): skip 422 locked-repo errors instead of failing

### DIFF
--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -1282,12 +1282,22 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 					} else {
 						err := reposProvider.RepositoryTeamAdd(ctx, repositoryTeamOperation.Repo, repositoryTeamOperation.Team, repositoryTeamOperation.Permission)
 						if err != nil {
-							l.Error(err, "error during adding repository&team", "repository", repositoryTeamOperation.Repo, "team", repositoryTeamOperation.Team, "permission", repositoryTeamOperation.Permission)
-							newStatus.Operations.RepositoryTeamOperations[i].State = v1.GithubRepoTeamOperationStateFailed
-							newStatus.Operations.RepositoryTeamOperations[i].Error = err.Error()
-							newStatus.Operations.RepositoryTeamOperations[i].Timestamp = metav1.Now()
-							statusChanged = true
-							failed = true
+							// 422 "This repository is locked and cannot be modified." — skip permanently;
+							// retrying will never succeed and only bloats the status.
+							if strings.Contains(err.Error(), "422") && strings.Contains(err.Error(), "locked") {
+								l.Info("adding repository&team skipped: repository is locked", "repository", repositoryTeamOperation.Repo, "team", repositoryTeamOperation.Team)
+								newStatus.Operations.RepositoryTeamOperations[i].State = v1.GithubRepoTeamOperationStateSkipped
+								newStatus.Operations.RepositoryTeamOperations[i].Error = err.Error()
+								newStatus.Operations.RepositoryTeamOperations[i].Timestamp = metav1.Now()
+								statusChanged = true
+							} else {
+								l.Error(err, "error during adding repository&team", "repository", repositoryTeamOperation.Repo, "team", repositoryTeamOperation.Team, "permission", repositoryTeamOperation.Permission)
+								newStatus.Operations.RepositoryTeamOperations[i].State = v1.GithubRepoTeamOperationStateFailed
+								newStatus.Operations.RepositoryTeamOperations[i].Error = err.Error()
+								newStatus.Operations.RepositoryTeamOperations[i].Timestamp = metav1.Now()
+								statusChanged = true
+								failed = true
+							}
 						} else {
 							l.Info("repository&team is added", "repository", repositoryTeamOperation.Repo, "team", repositoryTeamOperation.Team, "permission", repositoryTeamOperation.Permission)
 							newStatus.Operations.RepositoryTeamOperations[i].State = v1.GithubRepoTeamOperationStateComplete

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -788,7 +788,6 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 				teamObservationsCount := 0
 				var teamMembersRateLimitResult *reconcile.Result
 				var teamMembersRateLimitErr string
-				var teamMembersEtagRequeue bool
 				for _, team := range teamsList {
 					members, merr := teamsProvider.Members(ctx, team)
 					if merr != nil {
@@ -803,12 +802,6 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 							teamMembersRateLimitErr = merr.Error()
 							break
 						}
-						if isEtagCacheInconsistency(merr) {
-							// Cache was stale; provider already invalidated it. Requeue for a fresh fetch.
-							// Do not set rate-limit state; this is a transient condition, not a rate limit.
-							teamMembersEtagRequeue = true
-							break
-						}
 						// Non-rate-limit error: treat as hard stop to avoid false-positive
 						// org-member removals from an incomplete team-member union.
 						l.Error(merr, "org-member calculator: error fetching team members, aborting safety check", "team", team)
@@ -819,10 +812,6 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 						teamMembersUnion[strings.ToLower(m)] = struct{}{}
 					}
 					teamObservationsCount++
-				}
-				if teamMembersEtagRequeue {
-					// Etag cache inconsistency is a transient condition; requeue without updating status.
-					return reconcile.Result{Requeue: true}, nil
 				}
 				if teamMembersRateLimitResult != nil {
 					githubOrganization.Status.OrganizationStatus = v1.GithubOrganizationStateRateLimited

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -788,6 +788,7 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 				teamObservationsCount := 0
 				var teamMembersRateLimitResult *reconcile.Result
 				var teamMembersRateLimitErr string
+				var teamMembersEtagRequeue bool
 				for _, team := range teamsList {
 					members, merr := teamsProvider.Members(ctx, team)
 					if merr != nil {
@@ -802,6 +803,12 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 							teamMembersRateLimitErr = merr.Error()
 							break
 						}
+						if isEtagCacheInconsistency(merr) {
+							// Cache was stale; provider already invalidated it. Requeue for a fresh fetch.
+							// Do not set rate-limit state; this is a transient condition, not a rate limit.
+							teamMembersEtagRequeue = true
+							break
+						}
 						// Non-rate-limit error: treat as hard stop to avoid false-positive
 						// org-member removals from an incomplete team-member union.
 						l.Error(merr, "org-member calculator: error fetching team members, aborting safety check", "team", team)
@@ -812,6 +819,10 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 						teamMembersUnion[strings.ToLower(m)] = struct{}{}
 					}
 					teamObservationsCount++
+				}
+				if teamMembersEtagRequeue {
+					// Etag cache inconsistency is a transient condition; requeue without updating status.
+					return reconcile.Result{Requeue: true}, nil
 				}
 				if teamMembersRateLimitResult != nil {
 					githubOrganization.Status.OrganizationStatus = v1.GithubOrganizationStateRateLimited
@@ -1282,18 +1293,19 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 					} else {
 						err := reposProvider.RepositoryTeamAdd(ctx, repositoryTeamOperation.Repo, repositoryTeamOperation.Team, repositoryTeamOperation.Permission)
 						if err != nil {
+							errMsg := err.Error()
 							// 422 "This repository is locked and cannot be modified." — skip permanently;
 							// retrying will never succeed and only bloats the status.
-							if strings.Contains(err.Error(), "422") && strings.Contains(err.Error(), "locked") {
-								l.Info("adding repository&team skipped: repository is locked", "repository", repositoryTeamOperation.Repo, "team", repositoryTeamOperation.Team)
+							if strings.Contains(errMsg, "422") && strings.Contains(errMsg, "This repository is locked") {
+								l.Info("adding repository&team skipped: repository is locked", "repository", repositoryTeamOperation.Repo, "team", repositoryTeamOperation.Team, "permission", repositoryTeamOperation.Permission)
 								newStatus.Operations.RepositoryTeamOperations[i].State = v1.GithubRepoTeamOperationStateSkipped
-								newStatus.Operations.RepositoryTeamOperations[i].Error = err.Error()
+								newStatus.Operations.RepositoryTeamOperations[i].Error = errMsg
 								newStatus.Operations.RepositoryTeamOperations[i].Timestamp = metav1.Now()
 								statusChanged = true
 							} else {
 								l.Error(err, "error during adding repository&team", "repository", repositoryTeamOperation.Repo, "team", repositoryTeamOperation.Team, "permission", repositoryTeamOperation.Permission)
 								newStatus.Operations.RepositoryTeamOperations[i].State = v1.GithubRepoTeamOperationStateFailed
-								newStatus.Operations.RepositoryTeamOperations[i].Error = err.Error()
+								newStatus.Operations.RepositoryTeamOperations[i].Error = errMsg
 								newStatus.Operations.RepositoryTeamOperations[i].Timestamp = metav1.Now()
 								statusChanged = true
 								failed = true

--- a/internal/controller/githuborganization_repository_test.go
+++ b/internal/controller/githuborganization_repository_test.go
@@ -234,4 +234,49 @@ var _ = Describe("Github Organization controller - repository team assignments",
 				"archived-repo must not appear in status.outOfPolicyRepositories")
 		}
 	})
+
+	It("skips (not fails) repository-team operations for locked repos", func() {
+		if !isMockMode() {
+			Skip("relies on mock-seeded locked repo; only valid in mock mode")
+		}
+		// The mock server seeds TEST_LOCKED_REPO ("locked-repo") with Locked: true.
+		// When the controller calls RepositoryTeamAdd for that repo the mock returns
+		// 422 "This repository is locked and cannot be modified."
+		// The controller must mark those ops as Skipped, not Failed, and the org
+		// must still reach the Complete state (no infinite retry loop).
+		Expect(ensureResourceCreated(ctx, orgCR)).To(Succeed())
+		Expect(ensureResourceCreated(ctx, tr)).To(Succeed())
+
+		// Wait for the reconcile to settle — Complete is expected because locked ops
+		// do not count as failures.
+		Eventually(func() repoguardsapv1.GithubOrganizationState {
+			cur := &repoguardsapv1.GithubOrganization{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNS, Name: orgResource}, cur); err != nil {
+				return ""
+			}
+			return cur.Status.OrganizationStatus
+		}, 3*timeout, interval).Should(Equal(repoguardsapv1.GithubOrganizationStateComplete))
+
+		cur := &repoguardsapv1.GithubOrganization{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNS, Name: orgResource}, cur)).To(Succeed())
+
+		// All ops referencing the locked repo must be Skipped, never Failed.
+		for _, op := range cur.Status.Operations.RepositoryTeamOperations {
+			if op.Repo == TEST_LOCKED_REPO {
+				Expect(op.State).To(Equal(repoguardsapv1.GithubRepoTeamOperationStateSkipped),
+					"locked-repo operations must be skipped, not failed")
+				Expect(op.Error).To(ContainSubstring("locked"),
+					"locked-repo skipped op must preserve the error message for auditability")
+			}
+		}
+		// Confirm at least one skipped op was recorded for the locked repo.
+		lockedOpCount := 0
+		for _, op := range cur.Status.Operations.RepositoryTeamOperations {
+			if op.Repo == TEST_LOCKED_REPO {
+				lockedOpCount++
+			}
+		}
+		Expect(lockedOpCount).To(BeNumerically(">", 0),
+			"expected at least one operation recorded for the locked repo")
+	})
 })

--- a/internal/controller/shared_resources_test.go
+++ b/internal/controller/shared_resources_test.go
@@ -76,6 +76,7 @@ const (
 
 	TEST_ENTERPRISE_TEAM = "enterprise-team"
 	TEST_ARCHIVED_REPO   = "archived-repo"
+	TEST_LOCKED_REPO     = "locked-repo"
 )
 
 func loadTestEnv() map[string]string {

--- a/internal/controller/suite_mock_test.go
+++ b/internal/controller/suite_mock_test.go
@@ -87,6 +87,9 @@ func startMockGitHubServer() {
 			// Archived repo — should be silently filtered by List() and never
 			// trigger repository-team operations.
 			{Name: TEST_ARCHIVED_REPO, Private: false, Archived: true},
+			// Locked repo — GitHub returns 422 "This repository is locked and cannot
+			// be modified." for team-add; the controller must skip, not fail.
+			{Name: TEST_LOCKED_REPO, Private: false, Locked: true},
 		},
 	}
 

--- a/internal/github/mock_server.go
+++ b/internal/github/mock_server.go
@@ -54,6 +54,7 @@ type MockRepo struct {
 	Visibility string // "public", "private", or "internal"; defaults derived from Private when empty
 	Archived   bool
 	Disabled   bool
+	Locked     bool // if true, PUT team-repo returns 422 "This repository is locked and cannot be modified."
 	Teams      []MockTeamWithPermission
 }
 
@@ -609,6 +610,12 @@ func registerMockHandlers(mux *http.ServeMux, cfg MockConfig) {
 				if repoEntry.Archived || repoEntry.Disabled {
 					stateMu.Unlock()
 					writeJSONError(w, `{"message":"Repository is archived."}`, http.StatusUnprocessableEntity)
+					return
+				}
+				// Reject team-repo mutations on locked repositories.
+				if repoEntry.Locked {
+					stateMu.Unlock()
+					writeJSONError(w, `{"message":"Validation Failed","errors":[{"resource":"TeamRepository","field":"data","code":"unprocessable","message":"This repository is locked and cannot be modified."}]}`, http.StatusUnprocessableEntity)
 					return
 				}
 				perms := teamRepoPerms[repoName]


### PR DESCRIPTION
## Problem

When `RepositoryTeamAdd` is called for a repository that is locked on the GitHub side, the API returns:

```
422 Validation Failed [{Resource:TeamRepository Field:data Code:unprocessable Message:This repository is locked and cannot be modified.}]
```

The controller was marking these operations as `failed`, which:
1. Kept the org in a permanent `failed` / retry loop — the operation can never succeed.
2. Caused the status payload to grow unbounded across reconcile cycles, eventually exceeding the etcd 3 MB limit (`Request entity too large: limit is 3145728`).

## Fix

Detect the 422 + "locked" error and mark the operation as `skipped` instead of `failed`. This mirrors the existing pattern for other permanently-unresolvable situations (e.g. dry-run, label not enabled, last-admin demotion).

## Behaviour after this fix

- Locked-repo operations are recorded as `skipped` with the error message preserved for auditability.
- They do not contribute to `FailedOperationsFound()`, so the org can resolve to `complete`.
- They do not re-queue as fresh `pending` ops on the next reconcile cycle (already in the calculator de-dup sets for `skipped` state from PR #185).
- Status payload stays bounded.

## Test plan

- [ ] Verified `make build` passes.
- [ ] Manually confirmed `tools--cia` org was stuck in failed state due to locked repos on `github.tools.sap/cia`.
- [ ] After this fix, locked-repo ops will be marked `skipped` and the org should resolve to `complete`.