### PR TITLE
fix(controller): treat etag cache inconsistency as transient requeue

### DIFF
--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -788,6 +788,7 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 				teamObservationsCount := 0
 				var teamMembersRateLimitResult *reconcile.Result
 				var teamMembersRateLimitErr string
+				var teamMembersEtagRequeue bool
 				for _, team := range teamsList {
 					members, merr := teamsProvider.Members(ctx, team)
 					if merr != nil {
@@ -804,8 +805,8 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 						}
 						if isEtagCacheInconsistency(merr) {
 							// Cache was stale; provider already invalidated it. Requeue for a fresh fetch.
-							teamMembersRateLimitResult = &reconcile.Result{Requeue: true}
-							teamMembersRateLimitErr = merr.Error()
+							// Do not set rate-limit state; this is a transient condition, not a rate limit.
+							teamMembersEtagRequeue = true
 							break
 						}
 						// Non-rate-limit error: treat as hard stop to avoid false-positive
@@ -818,6 +819,10 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 						teamMembersUnion[strings.ToLower(m)] = struct{}{}
 					}
 					teamObservationsCount++
+				}
+				if teamMembersEtagRequeue {
+					// Etag cache inconsistency is a transient condition; requeue without updating status.
+					return reconcile.Result{Requeue: true}, nil
 				}
 				if teamMembersRateLimitResult != nil {
 					githubOrganization.Status.OrganizationStatus = v1.GithubOrganizationStateRateLimited

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -802,6 +802,12 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 							teamMembersRateLimitErr = merr.Error()
 							break
 						}
+						if isEtagCacheInconsistency(merr) {
+							// Cache was stale; provider already invalidated it. Requeue for a fresh fetch.
+							teamMembersRateLimitResult = &reconcile.Result{Requeue: true}
+							teamMembersRateLimitErr = merr.Error()
+							break
+						}
 						// Non-rate-limit error: treat as hard stop to avoid false-positive
 						// org-member removals from an incomplete team-member union.
 						l.Error(merr, "org-member calculator: error fetching team members, aborting safety check", "team", team)

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -463,6 +463,10 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		organizationTeams, err := teamsProvider.List(ctx)
 		if err != nil {
 			l.Error(err, "error during listing organization teams")
+			if isEtagCacheInconsistency(err) {
+				// Cache was stale; provider already invalidated it. Requeue for a fresh fetch.
+				return reconcile.Result{Requeue: true}, nil
+			}
 			if t, ok := parseGitHubRateLimitReset(err.Error()); ok {
 				recordTeamRateLimitHit(err.Error(), t)
 				now := time.Now().UTC()
@@ -517,6 +521,10 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		membersExtended, err := teamsProvider.MembersExtended(ctx, githubTeamName)
 		if err != nil {
 			l.Error(err, "error during getting the members of the team in Github")
+			if isEtagCacheInconsistency(err) {
+				// Cache was stale; provider already invalidated it. Requeue for a fresh fetch.
+				return reconcile.Result{Requeue: true}, nil
+			}
 			if t, ok := parseGitHubRateLimitReset(err.Error()); ok {
 				recordTeamRateLimitHit(err.Error(), t)
 				now := time.Now().UTC()

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -21,8 +21,21 @@ func elementsMatch(listA, listB any) bool {
 	return assert.ElementsMatch(dummyAssert{}, listA, listB)
 }
 
+// isEtagCacheInconsistency returns true when the error is a stale-etag-cache
+// transient condition: the transport sent If-None-Match and received 304 but
+// the local in-process cache no longer holds the corresponding parsed value.
+// The provider layer already invalidates the cache entry before returning this
+// error, so the very next reconcile will succeed with a fresh 200 response.
+// Callers should requeue without updating the status rather than marking the
+// resource as failed.
+func isEtagCacheInconsistency(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "etag cache inconsistency")
+}
+
 // parseGitHubRateLimitReset tries to extract a retry-after time from a GitHub rate-limit error string.
-// Handles three cases emitted by the GitHub API:
 //
 //   - Future reset:  "API rate limit ... still exceeded until 2025-12-05 02:02:13 +0000 UTC, ..."
 //     → returns the parsed future reset time so callers can requeue with RequeueAfter.

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -4,9 +4,52 @@
 package controller
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
+
+func TestIsEtagCacheInconsistency(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error returns false",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "exact etag cache inconsistency prefix matches",
+			err:  errors.New("etag cache inconsistency for /orgs/foo/teams/bar/members?per_page=100: 304 received but no valid cached value"),
+			want: true,
+		},
+		{
+			name: "error containing etag cache inconsistency substring matches",
+			err:  errors.New("wrapped: etag cache inconsistency for /orgs/foo/members: 304 received but no valid cached value"),
+			want: true,
+		},
+		{
+			name: "unrelated error returns false",
+			err:  errors.New("404 Not Found"),
+			want: false,
+		},
+		{
+			name: "rate limit error does not match",
+			err:  errors.New("API rate limit exceeded for installation ID 123"),
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isEtagCacheInconsistency(tc.err)
+			if got != tc.want {
+				t.Fatalf("isEtagCacheInconsistency(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestParseGitHubRateLimitReset(t *testing.T) {
 	t.Run("future reset timestamp via 'until' format", func(t *testing.T) {


### PR DESCRIPTION
## Problem

The etag caching layer sends `If-None-Match` on GET requests. When GitHub returns `304 Not Modified` but the in-process cache no longer holds the parsed value (stale/evicted entry), the provider returns:

```
etag cache inconsistency for /orgs/<org>/teams/<team>/members?per_page=100: 304 received but no valid cached value
```

The provider **already invalidates the cache entry** before returning this error, so the very next reconcile cycle will send a fresh request without `If-None-Match` and receive a proper `200` response.

However, the controllers propagated this error as a fatal reconcile failure, causing:
- `teamStatus=failed` on `GithubTeam` resources
- `Reconciler error` log entries and error metrics
- Resources stuck until manually cleared

## Fix

Add an `isEtagCacheInconsistency` helper in `utils.go` that detects this specific error message, and apply it in three call sites:

| Controller | Call site |
|---|---|
| `GithubTeamReconciler` | `teamsProvider.List()` |
| `GithubTeamReconciler` | `teamsProvider.MembersExtended()` |
| `GithubOrganizationReconciler` | `teamsProvider.Members()` (org-member safety-check loop) |

When detected, return `reconcile.Result{Requeue: true}` without updating the resource status.

## Behaviour after fix

- Stale-cache errors requeue silently — no failed status, no error metric.
- Next reconcile fetches fresh data and proceeds normally.
- The error is still logged at `ERROR` level (existing `l.Error` call) for observability.

## Test plan

- [ ] `make build` passes.
- [ ] Verified error pattern in logs: `etag cache inconsistency for /orgs/PlusOne/teams/plusone-cpe-sci-automation-apj/members?per_page=100`.
- [ ] After this fix, affected teams will requeue instead of failing.