### PR TITLE
fix(controller): set orphaned GithubTeam status to complete on reconcile

### DIFF
--- a/.claude/commands/check-status.md
+++ b/.claude/commands/check-status.md
@@ -167,7 +167,6 @@ kubectl get githubteam -A -o json | jq -r '
     name: .metadata.name,
     labels: {
       dryRun:                  (.metadata.labels["repo-guard.cloudoperators.dev/dryRun"] // ""),
-      orphaned:                (.metadata.labels["repo-guard.cloudoperators.dev/orphaned"] // ""),
       addUser:                 (.metadata.labels["repo-guard.cloudoperators.dev/addUser"] // ""),
       removeUser:              (.metadata.labels["repo-guard.cloudoperators.dev/removeUser"] // ""),
       disableInternalUsernames:(.metadata.labels["repo-guard.cloudoperators.dev/disableInternalUsernames"] // ""),
@@ -185,7 +184,7 @@ kubectl get githubteam -A -o json | jq -r '
       pending:  ([(.status.operations // [] | .[] | select(.state=="pending"))]  | length)
     }
   } |
-  "\(.ns)/\(.name)\n  labels: dryRun=\(.labels.dryRun) orphaned=\(.labels.orphaned) addUser=\(.labels.addUser) removeUser=\(.labels.removeUser)\n         disableInternalUsernames=\(.labels.disableInternalUsernames) requireVerifiedEmail=\(.labels.requireVerifiedEmail)\n         failedTTL=\(.labels.failedTTL) completedTTL=\(.labels.completedTTL) notfoundTTL=\(.labels.notfoundTTL) skippedTTL=\(.labels.skippedTTL)\n  ops:    failed=\(.ops.failed) complete=\(.ops.complete) notfound=\(.ops.notfound) skipped=\(.ops.skipped) pending=\(.ops.pending)"
+  "\(.ns)/\(.name)\n  labels: dryRun=\(.labels.dryRun) addUser=\(.labels.addUser) removeUser=\(.labels.removeUser)\n         disableInternalUsernames=\(.labels.disableInternalUsernames) requireVerifiedEmail=\(.labels.requireVerifiedEmail)\n         failedTTL=\(.labels.failedTTL) completedTTL=\(.labels.completedTTL) notfoundTTL=\(.labels.notfoundTTL) skippedTTL=\(.labels.skippedTTL)\n  ops:    failed=\(.ops.failed) complete=\(.ops.complete) notfound=\(.ops.notfound) skipped=\(.ops.skipped) pending=\(.ops.pending)"
 '
 ```
 
@@ -212,7 +211,6 @@ For each resource, flag the following conditions:
 - `addUser=true` with failed add-user operations.
 - `removeUser=true` with failed remove-user operations.
 - `dryRun=true` — mutations suppressed.
-- `orphaned=true` — team is marked orphaned; controller will not manage memberships.
 
 ```bash
 # Quick anomaly scan: resources with failed ops but no failedTTL configured
@@ -250,13 +248,6 @@ kubectl get githubteam -A -o json | jq -r '
   .items[] |
   select(.metadata.labels["repo-guard.cloudoperators.dev/dryRun"] == "true") |
   "GithubTeam \(.metadata.namespace)/\(.metadata.name) — DRY RUN active (mutations suppressed)"
-'
-
-echo "=== Orphaned GithubTeams ==="
-kubectl get githubteam -A -o json | jq -r '
-  .items[] |
-  select(.metadata.labels["repo-guard.cloudoperators.dev/orphaned"] != null) |
-  "GithubTeam \(.metadata.namespace)/\(.metadata.name) — orphaned=\(.metadata.labels["repo-guard.cloudoperators.dev/orphaned"]) (membership management disabled)"
 '
 ```
 
@@ -401,4 +392,3 @@ Present the findings in the following structure:
   - Org ops (`status.operations.{organizationOwnerOperations, teamOperations, repoOperations}`): `complete`, `failed`, `skipped` observed; `skipped` ops in orgs accumulate indefinitely (no `skippedTTL` label for orgs)
 - TTL labels take a Go duration string (e.g. `1h`, `24h`, `7d`). An empty or invalid value disables cleanup.
 - `dryRun=true` suppresses all GitHub API mutations for that resource — add/remove operations are logged but not executed.
-- `orphaned=true` on a GithubTeam disables membership management entirely for that team.

--- a/README.md
+++ b/README.md
@@ -416,7 +416,6 @@ GithubTeam labels:
 | `repo-guard.cloudoperators.dev/dryRun` | "true"/"false" | When "true", no member changes are made on GitHub; status shows planned operations. | "false" |
 | `repo-guard.cloudoperators.dev/disableInternalUsernames` | "true"/"false" | When "true", members where GreenhouseID == GithubUsername are filtered out (avoids using internal IDs externally). | "false" |
 | `repo-guard.cloudoperators.dev/require-verified-domain-email` | <domain> | When set, only members with a verified email under this domain (as reported in their `GithubAccountLink` multi-org results) are allowed. | Not set |
-| `repo-guard.cloudoperators.dev/orphaned` | "true" | Informational label set by the controller when the team is considered orphaned. Do not set manually. | Not set (controller-managed) |
 | `repo-guard.cloudoperators.dev/failedTTL` | Go duration | Clears failed operations and error after the duration since last status timestamp. | Not set |
 | `repo-guard.cloudoperators.dev/completedTTL` | Go duration | Clears completed operations after the duration since last status timestamp. | Not set |
 | `repo-guard.cloudoperators.dev/notfoundTTL` | Go duration | Clears operations in "notfound" state after the duration since last status timestamp. | Not set |

--- a/docs/crds/github-team.md
+++ b/docs/crds/github-team.md
@@ -114,4 +114,4 @@ See the full [Labels Reference](../operations/labels#githubteam-labels) for all 
 | `repo-guard.cloudoperators.dev/dryRun` | Prevent mutations; write planned operations to status. |
 | `repo-guard.cloudoperators.dev/disableInternalUsernames` | Filter out members where GreenhouseID matches GithubUsername. |
 | `repo-guard.cloudoperators.dev/require-verified-domain-email` | Only allow members with a verified email under the specified domain. |
-| `repo-guard.cloudoperators.dev/orphaned` | Set by the controller when the team has no known parent organization. Do not set manually. |
+

--- a/docs/operations/labels.md
+++ b/docs/operations/labels.md
@@ -38,7 +38,6 @@ Labels control the behavior of Repo Guard controllers. All labels live under `me
 | `repo-guard.cloudoperators.dev/dryRun` | `"true"` / `"false"` | When `"true"`, no member changes are made; status shows planned operations. | `"false"` |
 | `repo-guard.cloudoperators.dev/disableInternalUsernames` | `"true"` / `"false"` | Filters out members where GreenhouseID == GithubUsername (avoids leaking internal IDs). | `"false"` |
 | `repo-guard.cloudoperators.dev/require-verified-domain-email` | `<domain>` | Only allows members with a verified email under this domain (from their `GithubAccountLink`). | Not set |
-| `repo-guard.cloudoperators.dev/orphaned` | `"true"` | Set by the controller when the team is considered orphaned. **Do not set manually.** | Controller-managed |
 | `repo-guard.cloudoperators.dev/failedTTL` | Go duration | Clears failed operations and error after the duration since last status timestamp. | Not set |
 | `repo-guard.cloudoperators.dev/completedTTL` | Go duration | Clears completed operations after the duration since last status timestamp. | Not set |
 | `repo-guard.cloudoperators.dev/notfoundTTL` | Go duration | Clears operations in `notfound` state after the duration since last status timestamp. | Not set |

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cloudoperators/repo-guard
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/cloudoperators/greenhouse v0.13.1

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -323,6 +323,7 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// the provider is removed.
 		if githubTeam.Status.TeamStatus != v1.GithubTeamStateComplete ||
 			len(githubTeam.Status.Members) > 0 ||
+			len(githubTeam.Status.Operations) > 0 ||
 			githubTeam.Status.TeamStatusError != "" {
 			githubTeam.Status.TeamStatus = v1.GithubTeamStateComplete
 			githubTeam.Status.TeamStatusTimestamp = metav1.Now()

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -418,9 +418,17 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// No provider configured: set status to complete with zero members so that
 		// ownersFromGithubTeams in the org controller does not treat this team as
 		// "not ready" and busy-loop with a 5-second requeue indefinitely.
-		if githubTeam.Status.TeamStatus != v1.GithubTeamStateComplete {
+		// Also clear Members, Operations and any prior error so stale data from a
+		// previously-reconciled team cannot leak into org owner calculations once
+		// the provider is removed.
+		if githubTeam.Status.TeamStatus != v1.GithubTeamStateComplete ||
+			len(githubTeam.Status.Members) > 0 ||
+			githubTeam.Status.TeamStatusError != "" {
 			githubTeam.Status.TeamStatus = v1.GithubTeamStateComplete
 			githubTeam.Status.TeamStatusTimestamp = metav1.Now()
+			githubTeam.Status.Members = nil
+			githubTeam.Status.Operations = nil
+			githubTeam.Status.TeamStatusError = ""
 			if uerr := r.Client.Status().Update(ctx, githubTeam); uerr != nil {
 				l.Error(uerr, "error during status update for orphaned team")
 				return reconcile.Result{}, uerr

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -15,18 +15,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "github.com/cloudoperators/repo-guard/api/v1"
@@ -302,13 +298,10 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return reconcile.Result{}, nil
 	}
 
-	// Orphaned team: no provider configured. Handle early before any GitHub API
-	// client or GithubOrganization lookups so that this path is fast and does not
-	// depend on those resources being ready yet.
+	// Orphaned team: no provider configured. Label it and fall through to the full
+	// reconcile so GitHub members are fetched and written to status as normal.
+	// TeamStatus is forced to complete at the end regardless of operations outcome.
 	if githubTeam.Spec.GreenhouseTeam == "" && githubTeam.Spec.ExternalMemberProvider == nil {
-		// Use RetryOnConflict with re-fetch consistent with the GreenhouseTeam-not-found
-		// orphaning path in this controller, so a stale resourceVersion from the initial
-		// Get does not cause a spurious conflict error. Skip the write if already labeled.
 		if githubTeam.Labels == nil || githubTeam.Labels[GITHUB_TEAMS_LABEL_ORPHANED] != "true" {
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				latest := &v1.GithubTeam{}
@@ -316,8 +309,6 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					return ferr
 				}
 				if latest.Labels[GITHUB_TEAMS_LABEL_ORPHANED] == "true" {
-					// Already labeled by a concurrent reconcile — skip the write but
-					// propagate latest so the status update below uses a fresh object.
 					githubTeam = latest
 					return nil
 				}
@@ -339,27 +330,6 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				return reconcile.Result{}, err
 			}
 		}
-		// No provider configured: set status to complete with zero members so that
-		// ownersFromGithubTeams in the org controller does not treat this team as
-		// "not ready" and busy-loop with a 5-second requeue indefinitely.
-		// Also clear Members, Operations and any prior error so stale data from a
-		// previously-reconciled team cannot leak into org owner calculations once
-		// the provider is removed.
-		if githubTeam.Status.TeamStatus != v1.GithubTeamStateComplete ||
-			len(githubTeam.Status.Members) > 0 ||
-			len(githubTeam.Status.Operations) > 0 ||
-			githubTeam.Status.TeamStatusError != "" {
-			githubTeam.Status.TeamStatus = v1.GithubTeamStateComplete
-			githubTeam.Status.TeamStatusTimestamp = metav1.Now()
-			githubTeam.Status.Members = nil
-			githubTeam.Status.Operations = nil
-			githubTeam.Status.TeamStatusError = ""
-			if uerr := r.Client.Status().Update(ctx, githubTeam); uerr != nil {
-				l.Error(uerr, "error during status update for orphaned team")
-				return reconcile.Result{}, uerr
-			}
-		}
-		return reconcile.Result{}, nil
 	}
 
 	// check for github instance
@@ -972,6 +942,12 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		statusChanged, newStatus := githubTeam.ChangeCalculator(greenHouseTeamMemberListExtended)
 
+		// Orphaned teams (no provider) always report complete so that
+		// ownersFromGithubTeams in the org controller never busy-loops on them.
+		if githubTeam.Labels[GITHUB_TEAMS_LABEL_ORPHANED] == "true" {
+			newStatus.TeamStatus = v1.GithubTeamStateComplete
+		}
+
 		if statusChanged {
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				githubTeamForUpdate := &v1.GithubTeam{}
@@ -1186,7 +1162,7 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		if statusChanged {
 			l.Info("status changed during operation processing")
-			if failed {
+			if failed && githubTeam.Labels[GITHUB_TEAMS_LABEL_ORPHANED] != "true" {
 				newStatus.TeamStatus = v1.GithubTeamStateFailed
 			} else {
 				if githubTeam.Labels != nil && githubTeam.Labels[GITHUB_TEAMS_LABEL_DRY_RUN] == GITHUB_TEAMS_LABEL_DRY_RUN_ENABLED_VALUE {
@@ -1230,19 +1206,9 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *GithubTeamReconciler) SetupWithManager(mgr ctrl.Manager) error {
-
-	selector := labels.NewSelector()
-	orphaned, _ := labels.NewRequirement(GITHUB_TEAMS_LABEL_ORPHANED, selection.NotIn, []string{"true"})
-	selector = selector.Add(*orphaned)
-
-	metav1LabelSelector, err := metav1.ParseToLabelSelector(selector.String())
-	if err != nil {
-		return err
-	}
-
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
-		For(&v1.GithubTeam{}, builder.WithPredicates(LabelSelectorPredicate(*metav1LabelSelector))).
+		For(&v1.GithubTeam{}).
 		Watches(&greenhousesapv1alpha1.Team{}, handler.EnqueueRequestsFromMapFunc(r.greenhouseTeamToGithubTeam)).
 		Watches(&v1.GithubAccountLink{}, handler.EnqueueRequestsFromMapFunc(r.githubAccountLinkToGithubTeam)).
 		Complete(r)
@@ -1447,16 +1413,6 @@ func extendGithubMembersWithGreenhouseIDs(ctx context.Context, members []github.
 	}
 
 	return out, nil
-}
-
-func LabelSelectorPredicate(s metav1.LabelSelector) predicate.Predicate {
-	selector, err := metav1.LabelSelectorAsSelector(&s)
-	if err != nil {
-		return predicate.Funcs{}
-	}
-	return predicate.NewPredicateFuncs(func(o client.Object) bool {
-		return selector.Matches(labels.Set(o.GetLabels()))
-	})
 }
 
 const GITHUB_TEAMS_LABEL_ORPHANED = "repo-guard.cloudoperators.dev/orphaned"

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -415,6 +415,18 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			l.Error(err, "error during label update")
 			return reconcile.Result{}, err
 		}
+		// No provider configured: set status to complete with zero members so that
+		// ownersFromGithubTeams in the org controller does not treat this team as
+		// "not ready" and busy-loop with a 5-second requeue indefinitely.
+		if githubTeam.Status.TeamStatus != v1.GithubTeamStateComplete {
+			githubTeam.Status.TeamStatus = v1.GithubTeamStateComplete
+			githubTeam.Status.TeamStatusTimestamp = metav1.Now()
+			if uerr := r.Client.Status().Update(ctx, githubTeam); uerr != nil {
+				l.Error(uerr, "error during status update for orphaned team")
+				return reconcile.Result{}, uerr
+			}
+		}
+		return reconcile.Result{}, nil
 	}
 	if githubTeam.Spec.ExternalMemberProvider != nil {
 		providersSet := 0

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -298,40 +298,6 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return reconcile.Result{}, nil
 	}
 
-	// Orphaned team: no provider configured. Label it and fall through to the full
-	// reconcile so GitHub members are fetched and written to status as normal.
-	// TeamStatus is forced to complete at the end regardless of operations outcome.
-	if githubTeam.Spec.GreenhouseTeam == "" && githubTeam.Spec.ExternalMemberProvider == nil {
-		if githubTeam.Labels == nil || githubTeam.Labels[GITHUB_TEAMS_LABEL_ORPHANED] != "true" {
-			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				latest := &v1.GithubTeam{}
-				if ferr := r.Get(ctx, req.NamespacedName, latest); ferr != nil {
-					return ferr
-				}
-				if latest.Labels[GITHUB_TEAMS_LABEL_ORPHANED] == "true" {
-					githubTeam = latest
-					return nil
-				}
-				if latest.Labels == nil {
-					latest.Labels = make(map[string]string)
-				}
-				latest.Labels[GITHUB_TEAMS_LABEL_ORPHANED] = "true"
-				if uerr := r.Update(ctx, latest); uerr != nil {
-					return uerr
-				}
-				githubTeam = latest
-				return nil
-			})
-			if err != nil {
-				if errors.IsNotFound(err) {
-					return reconcile.Result{}, nil
-				}
-				l.Error(err, "error during label update")
-				return reconcile.Result{}, err
-			}
-		}
-	}
-
 	// check for github instance
 	githubInstance := &v1.Github{}
 	var githubClient githubapp.ClientCreator
@@ -592,27 +558,7 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			err = r.Get(ctx, types.NamespacedName{Name: githubTeam.Spec.GreenhouseTeam, Namespace: req.Namespace}, &greenHouseTeam)
 			if err != nil {
 				if errors.IsNotFound(err) {
-					l.Info("Team is not found in Kubernetes. GithubTeam will be labeled as orphaned", "Team", githubTeam.Spec.GreenhouseTeam)
-					// Orphaned GithubTeam - use RetryOnConflict with re-fetch to get the latest
-					// resourceVersion before updating, consistent with other label updates in this controller.
-					err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						latest := &v1.GithubTeam{}
-						if ferr := r.Get(ctx, req.NamespacedName, latest); ferr != nil {
-							return ferr
-						}
-						if latest.Labels == nil {
-							latest.Labels = make(map[string]string)
-						}
-						latest.Labels[GITHUB_TEAMS_LABEL_ORPHANED] = "true"
-						return r.Update(ctx, latest)
-					})
-					if err != nil {
-						if errors.IsNotFound(err) {
-							return reconcile.Result{}, nil
-						}
-						l.Error(err, "error during label update")
-						return reconcile.Result{}, err
-					}
+					l.Info("GreenhouseTeam not found; skipping reconcile until it exists", "Team", githubTeam.Spec.GreenhouseTeam)
 					return reconcile.Result{}, nil
 				} else {
 					l.Error(err, "error during getting the Team for GithubTeam")
@@ -942,9 +888,10 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		statusChanged, newStatus := githubTeam.ChangeCalculator(greenHouseTeamMemberListExtended)
 
-		// Orphaned teams (no provider) always report complete so that
-		// ownersFromGithubTeams in the org controller never busy-loops on them.
-		if githubTeam.Labels[GITHUB_TEAMS_LABEL_ORPHANED] == "true" {
+		// Teams with no provider (no GreenhouseTeam, no ExternalMemberProvider) always
+		// report complete so that ownersFromGithubTeams in the org controller never
+		// busy-loops on them.
+		if githubTeam.Spec.GreenhouseTeam == "" && githubTeam.Spec.ExternalMemberProvider == nil {
 			newStatus.TeamStatus = v1.GithubTeamStateComplete
 		}
 
@@ -1162,7 +1109,8 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		if statusChanged {
 			l.Info("status changed during operation processing")
-			if failed && githubTeam.Labels[GITHUB_TEAMS_LABEL_ORPHANED] != "true" {
+			isNoProvider := githubTeam.Spec.GreenhouseTeam == "" && githubTeam.Spec.ExternalMemberProvider == nil
+		if failed && !isNoProvider {
 				newStatus.TeamStatus = v1.GithubTeamStateFailed
 			} else {
 				if githubTeam.Labels != nil && githubTeam.Labels[GITHUB_TEAMS_LABEL_DRY_RUN] == GITHUB_TEAMS_LABEL_DRY_RUN_ENABLED_VALUE {
@@ -1414,8 +1362,6 @@ func extendGithubMembersWithGreenhouseIDs(ctx context.Context, members []github.
 
 	return out, nil
 }
-
-const GITHUB_TEAMS_LABEL_ORPHANED = "repo-guard.cloudoperators.dev/orphaned"
 
 const GITHUB_TEAMS_LABEL_DRY_RUN = "repo-guard.cloudoperators.dev/dryRun"
 const GITHUB_TEAMS_LABEL_DRY_RUN_ENABLED_VALUE = "true"

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -306,14 +306,32 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// client or GithubOrganization lookups so that this path is fast and does not
 	// depend on those resources being ready yet.
 	if githubTeam.Spec.GreenhouseTeam == "" && githubTeam.Spec.ExternalMemberProvider == nil {
-		if githubTeam.Labels == nil {
-			githubTeam.Labels = make(map[string]string)
-		}
-		githubTeam.Labels[GITHUB_TEAMS_LABEL_ORPHANED] = "true"
-		err := r.Update(ctx, githubTeam)
-		if err != nil {
-			l.Error(err, "error during label update")
-			return reconcile.Result{}, err
+		// Use RetryOnConflict with re-fetch consistent with the GreenhouseTeam-not-found
+		// orphaning path in this controller, so a stale resourceVersion from the initial
+		// Get does not cause a spurious conflict error. Skip the write if already labeled.
+		if githubTeam.Labels == nil || githubTeam.Labels[GITHUB_TEAMS_LABEL_ORPHANED] != "true" {
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				latest := &v1.GithubTeam{}
+				if ferr := r.Get(ctx, req.NamespacedName, latest); ferr != nil {
+					return ferr
+				}
+				if latest.Labels == nil {
+					latest.Labels = make(map[string]string)
+				}
+				latest.Labels[GITHUB_TEAMS_LABEL_ORPHANED] = "true"
+				if uerr := r.Update(ctx, latest); uerr != nil {
+					return uerr
+				}
+				githubTeam = latest
+				return nil
+			})
+			if err != nil {
+				if errors.IsNotFound(err) {
+					return reconcile.Result{}, nil
+				}
+				l.Error(err, "error during label update")
+				return reconcile.Result{}, err
+			}
 		}
 		// No provider configured: set status to complete with zero members so that
 		// ownersFromGithubTeams in the org controller does not treat this team as

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -315,6 +315,12 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				if ferr := r.Get(ctx, req.NamespacedName, latest); ferr != nil {
 					return ferr
 				}
+				if latest.Labels[GITHUB_TEAMS_LABEL_ORPHANED] == "true" {
+					// Already labeled by a concurrent reconcile — skip the write but
+					// propagate latest so the status update below uses a fresh object.
+					githubTeam = latest
+					return nil
+				}
 				if latest.Labels == nil {
 					latest.Labels = make(map[string]string)
 				}

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -302,6 +302,41 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return reconcile.Result{}, nil
 	}
 
+	// Orphaned team: no provider configured. Handle early before any GitHub API
+	// client or GithubOrganization lookups so that this path is fast and does not
+	// depend on those resources being ready yet.
+	if githubTeam.Spec.GreenhouseTeam == "" && githubTeam.Spec.ExternalMemberProvider == nil {
+		if githubTeam.Labels == nil {
+			githubTeam.Labels = make(map[string]string)
+		}
+		githubTeam.Labels[GITHUB_TEAMS_LABEL_ORPHANED] = "true"
+		err := r.Update(ctx, githubTeam)
+		if err != nil {
+			l.Error(err, "error during label update")
+			return reconcile.Result{}, err
+		}
+		// No provider configured: set status to complete with zero members so that
+		// ownersFromGithubTeams in the org controller does not treat this team as
+		// "not ready" and busy-loop with a 5-second requeue indefinitely.
+		// Also clear Members, Operations and any prior error so stale data from a
+		// previously-reconciled team cannot leak into org owner calculations once
+		// the provider is removed.
+		if githubTeam.Status.TeamStatus != v1.GithubTeamStateComplete ||
+			len(githubTeam.Status.Members) > 0 ||
+			githubTeam.Status.TeamStatusError != "" {
+			githubTeam.Status.TeamStatus = v1.GithubTeamStateComplete
+			githubTeam.Status.TeamStatusTimestamp = metav1.Now()
+			githubTeam.Status.Members = nil
+			githubTeam.Status.Operations = nil
+			githubTeam.Status.TeamStatusError = ""
+			if uerr := r.Client.Status().Update(ctx, githubTeam); uerr != nil {
+				l.Error(uerr, "error during status update for orphaned team")
+				return reconcile.Result{}, uerr
+			}
+		}
+		return reconcile.Result{}, nil
+	}
+
 	// check for github instance
 	githubInstance := &v1.Github{}
 	var githubClient githubapp.ClientCreator
@@ -402,37 +437,6 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err != nil {
 			l.Error(err, "error during status update")
 			return reconcile.Result{}, err
-		}
-		return reconcile.Result{}, nil
-	}
-	if githubTeam.Spec.GreenhouseTeam == "" && githubTeam.Spec.ExternalMemberProvider == nil {
-		if githubTeam.Labels == nil {
-			githubTeam.Labels = make(map[string]string)
-		}
-		githubTeam.Labels[GITHUB_TEAMS_LABEL_ORPHANED] = "true"
-		err := r.Update(ctx, githubTeam)
-		if err != nil {
-			l.Error(err, "error during label update")
-			return reconcile.Result{}, err
-		}
-		// No provider configured: set status to complete with zero members so that
-		// ownersFromGithubTeams in the org controller does not treat this team as
-		// "not ready" and busy-loop with a 5-second requeue indefinitely.
-		// Also clear Members, Operations and any prior error so stale data from a
-		// previously-reconciled team cannot leak into org owner calculations once
-		// the provider is removed.
-		if githubTeam.Status.TeamStatus != v1.GithubTeamStateComplete ||
-			len(githubTeam.Status.Members) > 0 ||
-			githubTeam.Status.TeamStatusError != "" {
-			githubTeam.Status.TeamStatus = v1.GithubTeamStateComplete
-			githubTeam.Status.TeamStatusTimestamp = metav1.Now()
-			githubTeam.Status.Members = nil
-			githubTeam.Status.Operations = nil
-			githubTeam.Status.TeamStatusError = ""
-			if uerr := r.Client.Status().Update(ctx, githubTeam); uerr != nil {
-				l.Error(uerr, "error during status update for orphaned team")
-				return reconcile.Result{}, uerr
-			}
 		}
 		return reconcile.Result{}, nil
 	}

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -584,28 +584,38 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// Completed/failed operations are left for TTL labels to manage.
 		// Status.Members reflects the GitHub-observed roster.
 		if isNoProvider {
-			// Filter out any pending operations that should not exist on a no-provider team.
-			var nonPendingOps []v1.GithubUserOperation
-			for _, op := range githubTeam.Status.Operations {
-				if op.State != v1.GithubUserOperationStatePending {
-					nonPendingOps = append(nonPendingOps, op)
-				}
-			}
-			hasPendingOps := len(nonPendingOps) != len(githubTeam.Status.Operations)
-			needsWrite := githubTeam.Status.TeamStatus != v1.GithubTeamStateComplete || hasPendingOps || githubTeam.Status.TeamStatusError != ""
+			// Determine whether a write is needed based on the snapshot we have.
+			// nonPendingOps is recomputed from latest inside the closure to avoid
+			// clobbering concurrent updates on conflict retries.
+			needsWrite := githubTeam.Status.TeamStatus != v1.GithubTeamStateComplete ||
+				githubTeam.Status.TeamStatusError != "" ||
+				func() bool {
+					for _, op := range githubTeam.Status.Operations {
+						if op.State == v1.GithubUserOperationStatePending {
+							return true
+						}
+					}
+					return false
+				}()
 			if needsWrite {
 				uerr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					latest := &v1.GithubTeam{}
 					if ferr := r.Get(ctx, req.NamespacedName, latest); ferr != nil {
 						return ferr
 					}
+					// Filter pending ops from the freshly re-fetched object to avoid
+					// overwriting any concurrent state changes on conflict retries.
+					var nonPendingOps []v1.GithubUserOperation
+					for _, op := range latest.Status.Operations {
+						if op.State != v1.GithubUserOperationStatePending {
+							nonPendingOps = append(nonPendingOps, op)
+						}
+					}
 					latest.Status.TeamStatus = v1.GithubTeamStateComplete
 					latest.Status.TeamStatusTimestamp = metav1.Now()
 					latest.Status.TeamStatusError = ""
 					latest.Status.Members = membersExtendedWithGithubUsernames
-					if hasPendingOps {
-						latest.Status.Operations = nonPendingOps
-					}
+					latest.Status.Operations = nonPendingOps
 					return r.Client.Status().Update(ctx, latest)
 				})
 				if uerr != nil {
@@ -1114,7 +1124,9 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				l.Error(uerr, "error during status update for no-provider team in pending state")
 				return reconcile.Result{}, uerr
 			}
-			return reconcile.Result{}, nil
+			// Requeue so the next reconcile runs the non-pending path and refreshes
+			// Status.Members from GitHub — required for ownersFromGithubTeams to find owners.
+			return reconcile.Result{Requeue: true}, nil
 		}
 
 		l.Info("there are pending operations in the status")

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -577,6 +577,44 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			// Do not return here; continue reconciliation to calculate desired state
 		}
 
+		// No-provider teams (no GreenhouseTeam, no ExternalMemberProvider): treat as
+		// terminal-complete after observing the GitHub-side members. Skip ChangeCalculator
+		// so we never generate spurious remove-ops against an empty desired list.
+		// Pending operations (which should not exist for no-provider teams) are cleared.
+		// Completed/failed operations are left for TTL labels to manage.
+		// Status.Members reflects the GitHub-observed roster.
+		if isNoProvider {
+			// Filter out any pending operations that should not exist on a no-provider team.
+			var nonPendingOps []v1.GithubUserOperation
+			for _, op := range githubTeam.Status.Operations {
+				if op.State != v1.GithubUserOperationStatePending {
+					nonPendingOps = append(nonPendingOps, op)
+				}
+			}
+			hasPendingOps := len(nonPendingOps) != len(githubTeam.Status.Operations)
+			needsWrite := githubTeam.Status.TeamStatus != v1.GithubTeamStateComplete || hasPendingOps
+			if needsWrite {
+				uerr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					latest := &v1.GithubTeam{}
+					if ferr := r.Get(ctx, req.NamespacedName, latest); ferr != nil {
+						return ferr
+					}
+					latest.Status.TeamStatus = v1.GithubTeamStateComplete
+					latest.Status.TeamStatusTimestamp = metav1.Now()
+					latest.Status.Members = membersExtendedWithGithubUsernames
+					if hasPendingOps {
+						latest.Status.Operations = nonPendingOps
+					}
+					return r.Client.Status().Update(ctx, latest)
+				})
+				if uerr != nil {
+					l.Error(uerr, "error during status update for no-provider team")
+					return reconcile.Result{}, uerr
+				}
+			}
+			return reconcile.Result{}, nil
+		}
+
 		greenHouseTeamMemberList := make([]string, 0)
 
 		if githubTeam.Spec.GreenhouseTeam != "" {
@@ -915,17 +953,6 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		statusChanged, newStatus := githubTeam.ChangeCalculator(greenHouseTeamMemberListExtended)
 
-		// Teams with no provider (no GreenhouseTeam, no ExternalMemberProvider) always
-		// report complete so that ownersFromGithubTeams in the org controller never
-		// busy-loops on them. Force statusChanged so the complete status is always
-		// written, even when ChangeCalculator found nothing to diff (e.g. empty team).
-		if githubTeam.Spec.GreenhouseTeam == "" && githubTeam.Spec.ExternalMemberProvider == nil {
-			newStatus.TeamStatus = v1.GithubTeamStateComplete
-			if !statusChanged {
-				statusChanged = newStatus.TeamStatus != githubTeam.Status.TeamStatus
-			}
-		}
-
 		if statusChanged {
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				githubTeamForUpdate := &v1.GithubTeam{}
@@ -1140,8 +1167,7 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		if statusChanged {
 			l.Info("status changed during operation processing")
-			isNoProvider := githubTeam.Spec.GreenhouseTeam == "" && githubTeam.Spec.ExternalMemberProvider == nil
-		if failed && !isNoProvider {
+			if failed {
 				newStatus.TeamStatus = v1.GithubTeamStateFailed
 			} else {
 				if githubTeam.Labels != nil && githubTeam.Labels[GITHUB_TEAMS_LABEL_DRY_RUN] == GITHUB_TEAMS_LABEL_DRY_RUN_ENABLED_VALUE {

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -440,6 +440,24 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// pending means there are still waiting operations on Github side, otherwise check for teams and members in each side
+	isNoProvider := githubTeam.Spec.GreenhouseTeam == "" && githubTeam.Spec.ExternalMemberProvider == nil
+	setFailed := func(fetchErr error) (reconcile.Result, error) {
+		uerr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latest := &v1.GithubTeam{}
+			if ferr := r.Get(ctx, req.NamespacedName, latest); ferr != nil {
+				return ferr
+			}
+			latest.Status.TeamStatus = v1.GithubTeamStateFailed
+			latest.Status.TeamStatusError = fetchErr.Error()
+			latest.Status.TeamStatusTimestamp = metav1.Now()
+			return r.Client.Status().Update(ctx, latest)
+		})
+		if uerr != nil {
+			l.Error(uerr, "error during status update")
+			return reconcile.Result{}, uerr
+		}
+		return reconcile.Result{}, nil
+	}
 	if githubTeam.Status.TeamStatus != v1.GithubTeamStatePendingOperations {
 
 		l.Info("there are no pending operations, status check started")
@@ -466,6 +484,9 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					return reconcile.Result{RequeueAfter: t.Sub(now)}, nil
 				}
 				return reconcile.Result{Requeue: true}, nil
+			}
+			if isNoProvider {
+				return setFailed(err)
 			}
 			return reconcile.Result{}, err
 		}
@@ -525,11 +546,17 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				}
 				return reconcile.Result{Requeue: true}, nil
 			}
+			if isNoProvider {
+				return setFailed(err)
+			}
 			return reconcile.Result{}, err
 		}
 		membersExtendedWithGithubUsernames, err := extendGithubMembersWithGreenhouseIDs(ctx, membersExtended, githubName, r.Client)
 		if err != nil {
 			l.Error(err, "error during extending the members of the team in Github")
+			if isNoProvider {
+				return setFailed(err)
+			}
 			return reconcile.Result{}, err
 		}
 
@@ -558,8 +585,8 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			err = r.Get(ctx, types.NamespacedName{Name: githubTeam.Spec.GreenhouseTeam, Namespace: req.Namespace}, &greenHouseTeam)
 			if err != nil {
 				if errors.IsNotFound(err) {
-					l.Info("GreenhouseTeam not found; skipping reconcile until it exists", "Team", githubTeam.Spec.GreenhouseTeam)
-					return reconcile.Result{}, nil
+					l.Error(err, "GreenhouseTeam not found; this is a configuration error", "Team", githubTeam.Spec.GreenhouseTeam)
+					return setFailed(fmt.Errorf("GreenhouseTeam %q not found", githubTeam.Spec.GreenhouseTeam))
 				} else {
 					l.Error(err, "error during getting the Team for GithubTeam")
 					return reconcile.Result{}, err

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -592,7 +592,7 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				}
 			}
 			hasPendingOps := len(nonPendingOps) != len(githubTeam.Status.Operations)
-			needsWrite := githubTeam.Status.TeamStatus != v1.GithubTeamStateComplete || hasPendingOps
+			needsWrite := githubTeam.Status.TeamStatus != v1.GithubTeamStateComplete || hasPendingOps || githubTeam.Status.TeamStatusError != ""
 			if needsWrite {
 				uerr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					latest := &v1.GithubTeam{}
@@ -601,6 +601,7 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					}
 					latest.Status.TeamStatus = v1.GithubTeamStateComplete
 					latest.Status.TeamStatusTimestamp = metav1.Now()
+					latest.Status.TeamStatusError = ""
 					latest.Status.Members = membersExtendedWithGithubUsernames
 					if hasPendingOps {
 						latest.Status.Operations = nonPendingOps
@@ -1085,6 +1086,36 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// if GithubTeamState is "pending" -- take actions on the Github side
 	if githubTeam.Status.TeamStatus == v1.GithubTeamStatePendingOperations {
+
+		// No-provider teams must never execute membership operations regardless of
+		// TeamStatus. If a no-provider team somehow accumulated PendingOperations
+		// (e.g. from an older buggy reconcile), resolve them to complete immediately
+		// rather than executing Add/Remove operations against GitHub.
+		if isNoProvider {
+			uerr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				latest := &v1.GithubTeam{}
+				if ferr := r.Get(ctx, req.NamespacedName, latest); ferr != nil {
+					return ferr
+				}
+				latest.Status.TeamStatus = v1.GithubTeamStateComplete
+				latest.Status.TeamStatusTimestamp = metav1.Now()
+				latest.Status.TeamStatusError = ""
+				// Clear all pending operations — they should not exist for a no-provider team.
+				var nonPending []v1.GithubUserOperation
+				for _, op := range latest.Status.Operations {
+					if op.State != v1.GithubUserOperationStatePending {
+						nonPending = append(nonPending, op)
+					}
+				}
+				latest.Status.Operations = nonPending
+				return r.Client.Status().Update(ctx, latest)
+			})
+			if uerr != nil {
+				l.Error(uerr, "error during status update for no-provider team in pending state")
+				return reconcile.Result{}, uerr
+			}
+			return reconcile.Result{}, nil
+		}
 
 		l.Info("there are pending operations in the status")
 

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -485,9 +485,6 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				}
 				return reconcile.Result{Requeue: true}, nil
 			}
-			if isNoProvider {
-				return setFailed(err)
-			}
 			return reconcile.Result{}, err
 		}
 
@@ -546,17 +543,11 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				}
 				return reconcile.Result{Requeue: true}, nil
 			}
-			if isNoProvider {
-				return setFailed(err)
-			}
 			return reconcile.Result{}, err
 		}
 		membersExtendedWithGithubUsernames, err := extendGithubMembersWithGreenhouseIDs(ctx, membersExtended, githubName, r.Client)
 		if err != nil {
 			l.Error(err, "error during extending the members of the team in Github")
-			if isNoProvider {
-				return setFailed(err)
-			}
 			return reconcile.Result{}, err
 		}
 

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -917,9 +917,13 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		// Teams with no provider (no GreenhouseTeam, no ExternalMemberProvider) always
 		// report complete so that ownersFromGithubTeams in the org controller never
-		// busy-loops on them.
+		// busy-loops on them. Force statusChanged so the complete status is always
+		// written, even when ChangeCalculator found nothing to diff (e.g. empty team).
 		if githubTeam.Spec.GreenhouseTeam == "" && githubTeam.Spec.ExternalMemberProvider == nil {
 			newStatus.TeamStatus = v1.GithubTeamStateComplete
+			if !statusChanged {
+				statusChanged = newStatus.TeamStatus != githubTeam.Status.TeamStatus
+			}
 		}
 
 		if statusChanged {

--- a/internal/controller/githubteam_controller_test.go
+++ b/internal/controller/githubteam_controller_test.go
@@ -133,11 +133,12 @@ var _ = Describe("Github Team controller", func() {
 				return ""
 			}
 			return cur.Status.TeamStatus
-		}, 3*timeout, interval).Should(Equal(repoguardsapv1.GithubTeamStateComplete))
+		}, 3*timeout, interval).Should(Equal(repoguardsapv1.GithubTeamState(repoguardsapv1.GithubTeamStateComplete)))
 
 		cur := &repoguardsapv1.GithubTeam{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: teamResourceName}, cur)).To(Succeed())
 		Expect(cur.Status.TeamStatusError).To(BeEmpty())
+		Expect(cur.Status.Operations).To(BeEmpty())
 	})
 
 	It("syncs greenhouse team members into GithubTeam status", func() {

--- a/internal/controller/githubteam_controller_test.go
+++ b/internal/controller/githubteam_controller_test.go
@@ -58,13 +58,17 @@ var _ = Describe("Github Team controller orphaned path", func() {
 		Expect(ensureResourceCreated(ctx, team)).To(Succeed())
 		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, team) })
 
+		// Use a generous timeout: the orphaned reconcile itself is instant, but in CI the
+		// single-suite process runs 32 other tests concurrently generating watch events that
+		// keep the controller workers busy. The team will be reconciled once it reaches the
+		// front of the queue, which can take up to several minutes under load.
 		Eventually(func() repoguardsapv1.GithubTeamState {
 			cur := &repoguardsapv1.GithubTeam{}
 			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: team.Name}, cur); err != nil {
 				return ""
 			}
 			return cur.Status.TeamStatus
-		}, 3*timeout, interval).Should(Equal(repoguardsapv1.GithubTeamStateComplete))
+		}, 6*timeout, interval).Should(Equal(repoguardsapv1.GithubTeamStateComplete))
 
 		cur := &repoguardsapv1.GithubTeam{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: team.Name}, cur)).To(Succeed())

--- a/internal/controller/githubteam_controller_test.go
+++ b/internal/controller/githubteam_controller_test.go
@@ -138,6 +138,7 @@ var _ = Describe("Github Team controller", func() {
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: team.Name}, cur)).To(Succeed())
 		Expect(cur.Labels).To(HaveKeyWithValue(GITHUB_TEAMS_LABEL_ORPHANED, "true"))
 		Expect(cur.Status.Members).To(BeEmpty())
+		Expect(cur.Status.Operations).To(BeEmpty())
 		Expect(cur.Status.TeamStatusError).To(BeEmpty())
 	})
 

--- a/internal/controller/githubteam_controller_test.go
+++ b/internal/controller/githubteam_controller_test.go
@@ -106,6 +106,41 @@ var _ = Describe("Github Team controller", func() {
 		})
 	})
 
+	It("labels orphaned team and sets complete status with no members", func() {
+		// A GithubTeam with neither a GreenhouseTeam ref nor an ExternalMemberProvider
+		// should be labelled orphaned and immediately reach TeamStatus=complete with
+		// zero members, so that ownersFromGithubTeams in the org controller never
+		// returns retryLater=true for it and causes a 5-second busy-loop on the org.
+		team := &repoguardsapv1.GithubTeam{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      uniqueTeamResourceName + "-orphan",
+				Namespace: uniqueNamespace,
+			},
+			Spec: repoguardsapv1.GithubTeamSpec{
+				Github:       uniqueGithubName,
+				Organization: orgName,
+				Team:         uniqueTeamName + "-orphan",
+				// GreenhouseTeam and ExternalMemberProvider intentionally absent.
+			},
+		}
+		Expect(ensureResourceCreated(ctx, team)).To(Succeed())
+		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, team) })
+
+		Eventually(func() repoguardsapv1.GithubTeamState {
+			cur := &repoguardsapv1.GithubTeam{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: team.Name}, cur); err != nil {
+				return ""
+			}
+			return cur.Status.TeamStatus
+		}, 3*timeout, interval).Should(Equal(repoguardsapv1.GithubTeamStateComplete))
+
+		cur := &repoguardsapv1.GithubTeam{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: team.Name}, cur)).To(Succeed())
+		Expect(cur.Labels).To(HaveKeyWithValue(GITHUB_TEAMS_LABEL_ORPHANED, "true"))
+		Expect(cur.Status.Members).To(BeEmpty())
+		Expect(cur.Status.TeamStatusError).To(BeEmpty())
+	})
+
 	It("syncs greenhouse team members into GithubTeam status", func() {
 		team := githubTeamTest.DeepCopy()
 		team.Name = uniqueTeamResourceName

--- a/internal/controller/githubteam_controller_test.go
+++ b/internal/controller/githubteam_controller_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Github Team controller", func() {
 		uniqueGithubSecretName string
 		uniqueTeamName         string
 		uniqueTeamResourceName string
+		uniqueOrphanTeamName   string
 
 		orgName string
 	)
@@ -51,6 +52,7 @@ var _ = Describe("Github Team controller", func() {
 		uniqueGithubSecretName = "sec-team-" + uniqueID
 		uniqueTeamName = "tm-" + uniqueID
 		uniqueTeamResourceName = fmt.Sprintf("%s--%s--%s", uniqueGithubName, orgName, uniqueTeamName)
+		uniqueOrphanTeamName = "orphan-" + uniqueID
 
 		nsObj = &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: uniqueNamespace}}
 		Expect(ensureResourceCreated(ctx, nsObj)).To(Succeed())
@@ -111,7 +113,7 @@ var _ = Describe("Github Team controller", func() {
 		// should go through the full reconcile (fetch GitHub members, sync operations)
 		// but always report TeamStatus=complete so that ownersFromGithubTeams in the
 		// org controller never busy-loops on it.
-		teamResourceName := fmt.Sprintf("%s--%s--%s", uniqueGithubName, orgName, "orphan-team")
+		teamResourceName := fmt.Sprintf("%s--%s--%s", uniqueGithubName, orgName, uniqueOrphanTeamName)
 		team := &repoguardsapv1.GithubTeam{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      teamResourceName,
@@ -120,7 +122,7 @@ var _ = Describe("Github Team controller", func() {
 			Spec: repoguardsapv1.GithubTeamSpec{
 				Github:       uniqueGithubName,
 				Organization: orgName,
-				Team:         "orphan-team",
+				Team:         uniqueOrphanTeamName,
 				// GreenhouseTeam and ExternalMemberProvider intentionally absent.
 			},
 		}
@@ -204,7 +206,7 @@ var _ = Describe("Github Team controller", func() {
 			}
 		}
 		_, _ = client.Teams.DeleteTeamBySlug(ctx, orgName, uniqueTeamName)
-		_, _ = client.Teams.DeleteTeamBySlug(ctx, orgName, "orphan-team")
+		_, _ = client.Teams.DeleteTeamBySlug(ctx, orgName, uniqueOrphanTeamName)
 
 		// Keep it small: enough to let reconcile settle in CI without long sleeps
 		Eventually(func() bool { return true }, 200*time.Millisecond, 200*time.Millisecond).Should(BeTrue())

--- a/internal/controller/githubteam_controller_test.go
+++ b/internal/controller/githubteam_controller_test.go
@@ -106,11 +106,11 @@ var _ = Describe("Github Team controller", func() {
 		})
 	})
 
-	It("labels orphaned team as complete and reflects GitHub members in status", func() {
+	It("reconciles no-provider team as complete and reflects GitHub members in status", func() {
 		// A GithubTeam with neither a GreenhouseTeam ref nor an ExternalMemberProvider
-		// should be labelled orphaned and go through the full reconcile (fetch GitHub
-		// members, sync operations) but always report TeamStatus=complete so that
-		// ownersFromGithubTeams in the org controller never busy-loops on it.
+		// should go through the full reconcile (fetch GitHub members, sync operations)
+		// but always report TeamStatus=complete so that ownersFromGithubTeams in the
+		// org controller never busy-loops on it.
 		teamResourceName := fmt.Sprintf("%s--%s--%s", uniqueGithubName, orgName, "orphan-team")
 		team := &repoguardsapv1.GithubTeam{
 			ObjectMeta: metav1.ObjectMeta{
@@ -137,7 +137,6 @@ var _ = Describe("Github Team controller", func() {
 
 		cur := &repoguardsapv1.GithubTeam{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: teamResourceName}, cur)).To(Succeed())
-		Expect(cur.Labels).To(HaveKeyWithValue(GITHUB_TEAMS_LABEL_ORPHANED, "true"))
 		Expect(cur.Status.TeamStatusError).To(BeEmpty())
 	})
 

--- a/internal/controller/githubteam_controller_test.go
+++ b/internal/controller/githubteam_controller_test.go
@@ -110,9 +110,9 @@ var _ = Describe("Github Team controller", func() {
 
 	It("reconciles no-provider team as complete with cleared operations and error", func() {
 		// A GithubTeam with neither a GreenhouseTeam ref nor an ExternalMemberProvider
-		// should go through the full reconcile (fetch GitHub members, sync operations)
-		// but always report TeamStatus=complete so that ownersFromGithubTeams in the
-		// org controller never busy-loops on it.
+		// should observe GitHub-side members and clear any stale pending ops, but skip
+		// ChangeCalculator entirely — always reporting TeamStatus=complete so that
+		// ownersFromGithubTeams in the org controller never busy-loops on it.
 		teamResourceName := fmt.Sprintf("%s--%s--%s", uniqueGithubName, orgName, uniqueOrphanTeamName)
 		team := &repoguardsapv1.GithubTeam{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/githubteam_controller_test.go
+++ b/internal/controller/githubteam_controller_test.go
@@ -19,6 +19,62 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// Orphaned-team tests use a minimal setup: the reconcile path exits before any
+// GitHub client or GithubOrganization lookup, so only a namespace is needed.
+var _ = Describe("Github Team controller orphaned path", func() {
+	var (
+		ctx             context.Context
+		nsObj           *v1.Namespace
+		uniqueNamespace string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		uniqueNamespace = "ns-orphan-" + fmt.Sprintf("%08x", testRand.Uint32())
+		nsObj = &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: uniqueNamespace}}
+		Expect(ensureResourceCreated(ctx, nsObj)).To(Succeed())
+		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, nsObj) })
+	})
+
+	It("labels orphaned team and sets complete status with no members", func() {
+		// A GithubTeam with neither a GreenhouseTeam ref nor an ExternalMemberProvider
+		// should be labelled orphaned and immediately reach TeamStatus=complete with
+		// zero members, so that ownersFromGithubTeams in the org controller never
+		// returns retryLater=true for it and causes a 5-second busy-loop on the org.
+		// The orphaned path exits before any GithubClients or GithubOrganization
+		// lookup, so no Github/secret/org setup is required.
+		team := &repoguardsapv1.GithubTeam{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "orphan-team-test",
+				Namespace: uniqueNamespace,
+			},
+			Spec: repoguardsapv1.GithubTeamSpec{
+				Github:       "gh-orphan-test",
+				Organization: "test-org",
+				Team:         "orphan-team",
+				// GreenhouseTeam and ExternalMemberProvider intentionally absent.
+			},
+		}
+		Expect(ensureResourceCreated(ctx, team)).To(Succeed())
+		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, team) })
+
+		Eventually(func() repoguardsapv1.GithubTeamState {
+			cur := &repoguardsapv1.GithubTeam{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: team.Name}, cur); err != nil {
+				return ""
+			}
+			return cur.Status.TeamStatus
+		}, 3*timeout, interval).Should(Equal(repoguardsapv1.GithubTeamStateComplete))
+
+		cur := &repoguardsapv1.GithubTeam{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: team.Name}, cur)).To(Succeed())
+		Expect(cur.Labels).To(HaveKeyWithValue(GITHUB_TEAMS_LABEL_ORPHANED, "true"))
+		Expect(cur.Status.Members).To(BeEmpty())
+		Expect(cur.Status.Operations).To(BeEmpty())
+		Expect(cur.Status.TeamStatusError).To(BeEmpty())
+	})
+})
+
 var _ = Describe("Github Team controller", func() {
 	var (
 		ctx context.Context
@@ -104,42 +160,6 @@ var _ = Describe("Github Team controller", func() {
 			_ = deleteIgnoreNotFound(ctx, k8sClient, secret)
 			_ = deleteIgnoreNotFound(ctx, k8sClient, nsObj)
 		})
-	})
-
-	It("labels orphaned team and sets complete status with no members", func() {
-		// A GithubTeam with neither a GreenhouseTeam ref nor an ExternalMemberProvider
-		// should be labelled orphaned and immediately reach TeamStatus=complete with
-		// zero members, so that ownersFromGithubTeams in the org controller never
-		// returns retryLater=true for it and causes a 5-second busy-loop on the org.
-		team := &repoguardsapv1.GithubTeam{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      uniqueTeamResourceName + "-orphan",
-				Namespace: uniqueNamespace,
-			},
-			Spec: repoguardsapv1.GithubTeamSpec{
-				Github:       uniqueGithubName,
-				Organization: orgName,
-				Team:         uniqueTeamName + "-orphan",
-				// GreenhouseTeam and ExternalMemberProvider intentionally absent.
-			},
-		}
-		Expect(ensureResourceCreated(ctx, team)).To(Succeed())
-		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, team) })
-
-		Eventually(func() repoguardsapv1.GithubTeamState {
-			cur := &repoguardsapv1.GithubTeam{}
-			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: team.Name}, cur); err != nil {
-				return ""
-			}
-			return cur.Status.TeamStatus
-		}, 3*timeout, interval).Should(Equal(repoguardsapv1.GithubTeamStateComplete))
-
-		cur := &repoguardsapv1.GithubTeam{}
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: team.Name}, cur)).To(Succeed())
-		Expect(cur.Labels).To(HaveKeyWithValue(GITHUB_TEAMS_LABEL_ORPHANED, "true"))
-		Expect(cur.Status.Members).To(BeEmpty())
-		Expect(cur.Status.Operations).To(BeEmpty())
-		Expect(cur.Status.TeamStatusError).To(BeEmpty())
 	})
 
 	It("syncs greenhouse team members into GithubTeam status", func() {

--- a/internal/controller/githubteam_controller_test.go
+++ b/internal/controller/githubteam_controller_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Github Team controller", func() {
 		})
 	})
 
-	It("reconciles no-provider team as complete and reflects GitHub members in status", func() {
+	It("reconciles no-provider team as complete with cleared operations and error", func() {
 		// A GithubTeam with neither a GreenhouseTeam ref nor an ExternalMemberProvider
 		// should go through the full reconcile (fetch GitHub members, sync operations)
 		// but always report TeamStatus=complete so that ownersFromGithubTeams in the

--- a/internal/controller/githubteam_controller_test.go
+++ b/internal/controller/githubteam_controller_test.go
@@ -19,66 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// Orphaned-team tests use a minimal setup: the reconcile path exits before any
-// GitHub client or GithubOrganization lookup, so only a namespace is needed.
-var _ = Describe("Github Team controller orphaned path", func() {
-	var (
-		ctx             context.Context
-		nsObj           *v1.Namespace
-		uniqueNamespace string
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		uniqueNamespace = "ns-orphan-" + fmt.Sprintf("%08x", testRand.Uint32())
-		nsObj = &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: uniqueNamespace}}
-		Expect(ensureResourceCreated(ctx, nsObj)).To(Succeed())
-		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, nsObj) })
-	})
-
-	It("labels orphaned team and sets complete status with no members", func() {
-		// A GithubTeam with neither a GreenhouseTeam ref nor an ExternalMemberProvider
-		// should be labelled orphaned and immediately reach TeamStatus=complete with
-		// zero members, so that ownersFromGithubTeams in the org controller never
-		// returns retryLater=true for it and causes a 5-second busy-loop on the org.
-		// The orphaned path exits before any GithubClients or GithubOrganization
-		// lookup, so no Github/secret/org setup is required.
-		team := &repoguardsapv1.GithubTeam{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "orphan-team-test",
-				Namespace: uniqueNamespace,
-			},
-			Spec: repoguardsapv1.GithubTeamSpec{
-				Github:       "gh-orphan-test",
-				Organization: "test-org",
-				Team:         "orphan-team",
-				// GreenhouseTeam and ExternalMemberProvider intentionally absent.
-			},
-		}
-		Expect(ensureResourceCreated(ctx, team)).To(Succeed())
-		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, team) })
-
-		// Use a generous timeout: the orphaned reconcile itself is instant, but in CI the
-		// single-suite process runs 32 other tests concurrently generating watch events that
-		// keep the controller workers busy. The team will be reconciled once it reaches the
-		// front of the queue, which can take up to several minutes under load.
-		Eventually(func() repoguardsapv1.GithubTeamState {
-			cur := &repoguardsapv1.GithubTeam{}
-			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: team.Name}, cur); err != nil {
-				return ""
-			}
-			return cur.Status.TeamStatus
-		}, 6*timeout, interval).Should(Equal(repoguardsapv1.GithubTeamStateComplete))
-
-		cur := &repoguardsapv1.GithubTeam{}
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: team.Name}, cur)).To(Succeed())
-		Expect(cur.Labels).To(HaveKeyWithValue(GITHUB_TEAMS_LABEL_ORPHANED, "true"))
-		Expect(cur.Status.Members).To(BeEmpty())
-		Expect(cur.Status.Operations).To(BeEmpty())
-		Expect(cur.Status.TeamStatusError).To(BeEmpty())
-	})
-})
-
 var _ = Describe("Github Team controller", func() {
 	var (
 		ctx context.Context
@@ -166,6 +106,41 @@ var _ = Describe("Github Team controller", func() {
 		})
 	})
 
+	It("labels orphaned team as complete and reflects GitHub members in status", func() {
+		// A GithubTeam with neither a GreenhouseTeam ref nor an ExternalMemberProvider
+		// should be labelled orphaned and go through the full reconcile (fetch GitHub
+		// members, sync operations) but always report TeamStatus=complete so that
+		// ownersFromGithubTeams in the org controller never busy-loops on it.
+		teamResourceName := fmt.Sprintf("%s--%s--%s", uniqueGithubName, orgName, "orphan-team")
+		team := &repoguardsapv1.GithubTeam{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      teamResourceName,
+				Namespace: uniqueNamespace,
+			},
+			Spec: repoguardsapv1.GithubTeamSpec{
+				Github:       uniqueGithubName,
+				Organization: orgName,
+				Team:         "orphan-team",
+				// GreenhouseTeam and ExternalMemberProvider intentionally absent.
+			},
+		}
+		Expect(ensureResourceCreated(ctx, team)).To(Succeed())
+		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, team) })
+
+		Eventually(func() repoguardsapv1.GithubTeamState {
+			cur := &repoguardsapv1.GithubTeam{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: teamResourceName}, cur); err != nil {
+				return ""
+			}
+			return cur.Status.TeamStatus
+		}, 3*timeout, interval).Should(Equal(repoguardsapv1.GithubTeamStateComplete))
+
+		cur := &repoguardsapv1.GithubTeam{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: uniqueNamespace, Name: teamResourceName}, cur)).To(Succeed())
+		Expect(cur.Labels).To(HaveKeyWithValue(GITHUB_TEAMS_LABEL_ORPHANED, "true"))
+		Expect(cur.Status.TeamStatusError).To(BeEmpty())
+	})
+
 	It("syncs greenhouse team members into GithubTeam status", func() {
 		team := githubTeamTest.DeepCopy()
 		team.Name = uniqueTeamResourceName
@@ -229,6 +204,7 @@ var _ = Describe("Github Team controller", func() {
 			}
 		}
 		_, _ = client.Teams.DeleteTeamBySlug(ctx, orgName, uniqueTeamName)
+		_, _ = client.Teams.DeleteTeamBySlug(ctx, orgName, "orphan-team")
 
 		// Keep it small: enough to let reconcile settle in CI without long sleeps
 		Eventually(func() bool { return true }, 200*time.Millisecond, 200*time.Millisecond).Should(BeTrue())

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -208,7 +208,7 @@ var _ = BeforeSuite(func() {
 
 	Expect((&GithubReconciler{Client: k8sManager.GetClient()}).SetupWithManager(k8sManager)).To(Succeed())
 	Expect((&GithubOrganizationReconciler{Client: k8sManager.GetClient()}).SetupWithManager(k8sManager)).To(Succeed())
-	Expect((&GithubTeamReconciler{Client: k8sManager.GetClient()}).SetupWithManager(k8sManager)).To(Succeed())
+	Expect((&GithubTeamReconciler{Client: k8sManager.GetClient(), MaxConcurrentReconciles: 5}).SetupWithManager(k8sManager)).To(Succeed())
 	Expect((&GithubAccountLinkReconciler{Client: k8sManager.GetClient()}).SetupWithManager(k8sManager)).To(Succeed())
 	Expect((&LDAPGroupProviderReconciler{Client: k8sManager.GetClient()}).SetupWithManager(k8sManager)).To(Succeed())
 	Expect((&ClusterLDAPGroupProviderReconciler{Client: k8sManager.GetClient()}).SetupWithManager(k8sManager)).To(Succeed())


### PR DESCRIPTION
## Problem

`GithubTeam` resources with neither a `greenhouseTeam` ref nor an `externalMemberProvider` have no membership source. The previous behavior set an `orphaned` label and proceeded to reconcile with an empty desired-members list, which could generate spurious remove-operations and left `teamStatus` as `""` indefinitely — never reaching `complete`.

`ownersFromGithubTeams` in the org controller treats any status other than `complete`, `dryRun`, or `failed` as "not ready" and returns `retryLater=true`, causing the parent `GithubOrganization` to busy-loop with `RequeueAfter=5s` forever.

Observed in production:
- `wdf--sci-network` stuck in a 5s requeue loop for **2d21h** — `sci-network-org-owner` team had no provider
- `com--sapcc` stuck in the same loop — `cc-github-organization-owner-tech` had no provider

## Fix

For teams with no `GreenhouseTeam` and no `ExternalMemberProvider` (`isNoProvider`), the reconcile now returns early after observing the GitHub-side members, before `ChangeCalculator` runs. This:

- **Prevents spurious remove-ops**: `ChangeCalculator` would diff GitHub members against an empty desired list, generating remove-operations. We skip it entirely.
- **Preserves GitHub-observed members**: `Status.Members` reflects the GitHub-side roster so `ownersFromGithubTeams` can find the owners.
- **Clears pending operations and stale errors**: Any pending ops that should not exist on a no-provider team are cleared; `TeamStatusError` is reset. Completed/failed operations are preserved for TTL labels to manage.
- **Always reaches `complete`**: Even if the team previously had `TeamStatus=PendingOperations`, the no-provider guard fires before operations are executed, resolving to `complete`.
- **Removes orphaned label**: The `repo-guard.cloudoperators.dev/orphaned` label concept has been removed from the controller (constant, predicate) and from all documentation.

## Test plan

- [x] `go build ./...` passes
- [x] `make controller-test` passes (all 33 specs)
- [x] No-provider test asserts `TeamStatus=complete`, empty `TeamStatusError`, and empty `Operations`