### PR TITLE
feat(controller): add forceReconcile label to trigger immediate reconcile

### DIFF
--- a/internal/controller/force_reconcile_test.go
+++ b/internal/controller/force_reconcile_test.go
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	repoguardsapv1 "github.com/cloudoperators/repo-guard/api/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("forceReconcile label", Ordered, func() {
+	var (
+		ctx    context.Context
+		github *repoguardsapv1.Github
+		secret *v1.Secret
+		org    *repoguardsapv1.GithubOrganization
+	)
+
+	BeforeAll(func() {
+		ctx = context.Background()
+
+		ghName := generateUniqueName("gh-force-reconcile")
+		secName := generateUniqueName("sec-force-reconcile")
+
+		operatorNsObj := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: TestOperatorNamespace}}
+		_ = ensureResourceCreated(ctx, operatorNsObj)
+
+		secret = githubComSecret.DeepCopy()
+		secret.Name = secName
+		secret.Namespace = TestOperatorNamespace
+		Expect(ensureResourceCreated(ctx, secret)).To(Succeed())
+
+		github = githubCom.DeepCopy()
+		github.Name = ghName
+		github.Namespace = ""
+		github.Spec.Secret = secName
+		Expect(ensureResourceCreated(ctx, github)).To(Succeed())
+
+		org = githubOrganizationGreenhouseSandboxForTeamTests.DeepCopy()
+		org.Name = fmt.Sprintf("%s--%s", ghName, TEST_ENV["ORGANIZATION"])
+		org.Spec.Github = ghName
+		Expect(ensureResourceCreated(ctx, org)).To(Succeed())
+
+		Eventually(func() repoguardsapv1.GithubState {
+			cur := &repoguardsapv1.Github{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: github.Name}, cur); err != nil {
+				return ""
+			}
+			return cur.Status.State
+		}, 3*timeout, interval).Should(Equal(repoguardsapv1.GithubStateRunning))
+	})
+
+	AfterAll(func() {
+		ctx := context.Background()
+		_ = deleteIgnoreNotFound(ctx, k8sClient, org)
+		_ = deleteIgnoreNotFound(ctx, k8sClient, github)
+		_ = deleteIgnoreNotFound(ctx, k8sClient, secret)
+	})
+
+	It("clears GithubOrganization status and re-reconciles when forceReconcile label is set", func() {
+		ctx := context.Background()
+
+		testOrg := githubOrganizationGreenhouseSandboxForTTLTests.DeepCopy()
+		testOrg.Name = generateUniqueName("force-reconcile-org")
+		testOrg.Spec.Github = github.Name
+		if testOrg.Labels == nil {
+			testOrg.Labels = map[string]string{}
+		}
+		testOrg.Labels[GITHUB_ORG_LABEL_FORCE_RECONCILE] = GITHUB_ORG_LABEL_FORCE_RECONCILE_VALUE
+		Expect(ensureResourceCreated(ctx, testOrg)).To(Succeed())
+		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, testOrg) })
+
+		// The controller should remove the label and clear the status.
+		// Once the label is gone, the forceReconcile logic has fired.
+		Eventually(func() bool {
+			cur := &repoguardsapv1.GithubOrganization{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: testOrg.Namespace, Name: testOrg.Name}, cur); err != nil {
+				return true
+			}
+			return cur.Labels[GITHUB_ORG_LABEL_FORCE_RECONCILE] == GITHUB_ORG_LABEL_FORCE_RECONCILE_VALUE
+		}, 3*timeout, interval).Should(BeFalse())
+	})
+
+	It("clears GithubTeam status and re-reconciles when forceReconcile label is set", func() {
+		ctx := context.Background()
+
+		teamName := "team-force-reconcile"
+		name := fmt.Sprintf("%s--%s--%s", github.Name, TEST_ENV["ORGANIZATION"], teamName)
+
+		t := &repoguardsapv1.GithubTeam{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: TEST_ENV["NAMESPACE"],
+				Labels: map[string]string{
+					"repo-guard.cloudoperators.dev/addUser":    "false",
+					"repo-guard.cloudoperators.dev/removeUser": "false",
+					GITHUB_TEAM_LABEL_FORCE_RECONCILE:          GITHUB_TEAM_LABEL_FORCE_RECONCILE_VALUE,
+				},
+			},
+			Spec: repoguardsapv1.GithubTeamSpec{
+				Github:       github.Name,
+				Organization: TEST_ENV["ORGANIZATION"],
+				Team:         teamName,
+			},
+		}
+		Expect(ensureResourceCreated(ctx, t)).To(Succeed())
+		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, t) })
+
+		// The controller should remove the label and clear the status.
+		// Once the label is gone, the forceReconcile logic has fired.
+		Eventually(func() bool {
+			cur := &repoguardsapv1.GithubTeam{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: TEST_ENV["NAMESPACE"], Name: name}, cur); err != nil {
+				return true
+			}
+			return cur.Labels[GITHUB_TEAM_LABEL_FORCE_RECONCILE] == GITHUB_TEAM_LABEL_FORCE_RECONCILE_VALUE
+		}, 3*timeout, interval).Should(BeFalse())
+	})
+})

--- a/internal/controller/force_reconcile_test.go
+++ b/internal/controller/force_reconcile_test.go
@@ -30,7 +30,7 @@ var _ = Describe("forceReconcile label", Ordered, func() {
 		secName := generateUniqueName("sec-force-reconcile")
 
 		operatorNsObj := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: TestOperatorNamespace}}
-		_ = ensureResourceCreated(ctx, operatorNsObj)
+		Expect(ensureResourceCreated(ctx, operatorNsObj)).To(Succeed())
 
 		secret = githubComSecret.DeepCopy()
 		secret.Name = secName

--- a/internal/controller/force_reconcile_test.go
+++ b/internal/controller/force_reconcile_test.go
@@ -67,29 +67,40 @@ var _ = Describe("forceReconcile label", Ordered, func() {
 	It("clears GithubOrganization status and re-reconciles when forceReconcile label is set", func() {
 		ctx := context.Background()
 
+		const sentinelError = "force-reconcile-sentinel-error"
+
 		testOrg := githubOrganizationGreenhouseSandboxForTTLTests.DeepCopy()
 		testOrg.Name = generateUniqueName("force-reconcile-org")
 		testOrg.Spec.Github = github.Name
 		if testOrg.Labels == nil {
 			testOrg.Labels = map[string]string{}
 		}
-		testOrg.Labels[GITHUB_ORG_LABEL_FORCE_RECONCILE] = GITHUB_ORG_LABEL_FORCE_RECONCILE_VALUE
 		Expect(ensureResourceCreated(ctx, testOrg)).To(Succeed())
 		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, testOrg) })
 
-		// The controller should remove the label and clear the status.
-		// Once the label is gone, the forceReconcile logic has fired.
-		Eventually(func() bool {
+		// Seed a failed status with a sentinel error so we can verify it is wiped.
+		Expect(updateStatusWithRetry(ctx, k8sClient, testOrg, func(cur *repoguardsapv1.GithubOrganization) {
+			cur.Status.OrganizationStatus = repoguardsapv1.GithubOrganizationStateFailed
+			cur.Status.OrganizationStatusError = sentinelError
+		})).To(Succeed())
+
+		// Set the forceReconcile label; the controller should wipe the status and remove the label.
+		Expect(labelWithRetry(ctx, k8sClient, testOrg, GITHUB_ORG_LABEL_FORCE_RECONCILE, GITHUB_ORG_LABEL_FORCE_RECONCILE_VALUE)).To(Succeed())
+
+		// Once the label is gone the forceReconcile path has run. Assert both that the label is
+		// removed and that the sentinel error is no longer present (status was actually wiped).
+		Eventually(func(g Gomega) {
 			cur := &repoguardsapv1.GithubOrganization{}
-			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: testOrg.Namespace, Name: testOrg.Name}, cur); err != nil {
-				return true
-			}
-			return cur.Labels[GITHUB_ORG_LABEL_FORCE_RECONCILE] == GITHUB_ORG_LABEL_FORCE_RECONCILE_VALUE
-		}, 3*timeout, interval).Should(BeFalse())
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testOrg.Namespace, Name: testOrg.Name}, cur)).To(Succeed())
+			g.Expect(cur.Labels[GITHUB_ORG_LABEL_FORCE_RECONCILE]).NotTo(Equal(GITHUB_ORG_LABEL_FORCE_RECONCILE_VALUE))
+			g.Expect(cur.Status.OrganizationStatusError).NotTo(Equal(sentinelError))
+		}, 3*timeout, interval).Should(Succeed())
 	})
 
 	It("clears GithubTeam status and re-reconciles when forceReconcile label is set", func() {
 		ctx := context.Background()
+
+		const sentinelError = "force-reconcile-sentinel-error"
 
 		teamName := "team-force-reconcile"
 		name := fmt.Sprintf("%s--%s--%s", github.Name, TEST_ENV["ORGANIZATION"], teamName)
@@ -101,7 +112,6 @@ var _ = Describe("forceReconcile label", Ordered, func() {
 				Labels: map[string]string{
 					"repo-guard.cloudoperators.dev/addUser":    "false",
 					"repo-guard.cloudoperators.dev/removeUser": "false",
-					GITHUB_TEAM_LABEL_FORCE_RECONCILE:          GITHUB_TEAM_LABEL_FORCE_RECONCILE_VALUE,
 				},
 			},
 			Spec: repoguardsapv1.GithubTeamSpec{
@@ -113,14 +123,22 @@ var _ = Describe("forceReconcile label", Ordered, func() {
 		Expect(ensureResourceCreated(ctx, t)).To(Succeed())
 		DeferCleanup(func() { _ = deleteIgnoreNotFound(ctx, k8sClient, t) })
 
-		// The controller should remove the label and clear the status.
-		// Once the label is gone, the forceReconcile logic has fired.
-		Eventually(func() bool {
+		// Seed a failed status with a sentinel error so we can verify it is wiped.
+		Expect(updateStatusWithRetry(ctx, k8sClient, t, func(cur *repoguardsapv1.GithubTeam) {
+			cur.Status.TeamStatus = repoguardsapv1.GithubTeamStateFailed
+			cur.Status.TeamStatusError = sentinelError
+		})).To(Succeed())
+
+		// Set the forceReconcile label; the controller should wipe the status and remove the label.
+		Expect(labelWithRetry(ctx, k8sClient, t, GITHUB_TEAM_LABEL_FORCE_RECONCILE, GITHUB_TEAM_LABEL_FORCE_RECONCILE_VALUE)).To(Succeed())
+
+		// Once the label is gone the forceReconcile path has run. Assert both that the label is
+		// removed and that the sentinel error is no longer present (status was actually wiped).
+		Eventually(func(g Gomega) {
 			cur := &repoguardsapv1.GithubTeam{}
-			if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: TEST_ENV["NAMESPACE"], Name: name}, cur); err != nil {
-				return true
-			}
-			return cur.Labels[GITHUB_TEAM_LABEL_FORCE_RECONCILE] == GITHUB_TEAM_LABEL_FORCE_RECONCILE_VALUE
-		}, 3*timeout, interval).Should(BeFalse())
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: TEST_ENV["NAMESPACE"], Name: name}, cur)).To(Succeed())
+			g.Expect(cur.Labels[GITHUB_TEAM_LABEL_FORCE_RECONCILE]).NotTo(Equal(GITHUB_TEAM_LABEL_FORCE_RECONCILE_VALUE))
+			g.Expect(cur.Status.TeamStatusError).NotTo(Equal(sentinelError))
+		}, 3*timeout, interval).Should(Succeed())
 	})
 })

--- a/internal/controller/force_reconcile_test.go
+++ b/internal/controller/force_reconcile_test.go
@@ -87,12 +87,13 @@ var _ = Describe("forceReconcile label", Ordered, func() {
 		// Set the forceReconcile label; the controller should wipe the status and remove the label.
 		Expect(labelWithRetry(ctx, k8sClient, testOrg, GITHUB_ORG_LABEL_FORCE_RECONCILE, GITHUB_ORG_LABEL_FORCE_RECONCILE_VALUE)).To(Succeed())
 
-		// Once the label is gone the forceReconcile path has run. Assert both that the label is
-		// removed and that the sentinel error is no longer present (status was actually wiped).
+		// Once the label is gone the forceReconcile path has run. Assert both that the label key
+		// is absent (not merely set to a different value) and that the sentinel error is cleared
+		// (status was actually wiped).
 		Eventually(func(g Gomega) {
 			cur := &repoguardsapv1.GithubOrganization{}
 			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testOrg.Namespace, Name: testOrg.Name}, cur)).To(Succeed())
-			g.Expect(cur.Labels[GITHUB_ORG_LABEL_FORCE_RECONCILE]).NotTo(Equal(GITHUB_ORG_LABEL_FORCE_RECONCILE_VALUE))
+			g.Expect(cur.Labels).NotTo(HaveKey(GITHUB_ORG_LABEL_FORCE_RECONCILE))
 			g.Expect(cur.Status.OrganizationStatusError).NotTo(Equal(sentinelError))
 		}, 3*timeout, interval).Should(Succeed())
 	})
@@ -132,12 +133,13 @@ var _ = Describe("forceReconcile label", Ordered, func() {
 		// Set the forceReconcile label; the controller should wipe the status and remove the label.
 		Expect(labelWithRetry(ctx, k8sClient, t, GITHUB_TEAM_LABEL_FORCE_RECONCILE, GITHUB_TEAM_LABEL_FORCE_RECONCILE_VALUE)).To(Succeed())
 
-		// Once the label is gone the forceReconcile path has run. Assert both that the label is
-		// removed and that the sentinel error is no longer present (status was actually wiped).
+		// Once the label is gone the forceReconcile path has run. Assert both that the label key
+		// is absent (not merely set to a different value) and that the sentinel error is cleared
+		// (status was actually wiped).
 		Eventually(func(g Gomega) {
 			cur := &repoguardsapv1.GithubTeam{}
 			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: TEST_ENV["NAMESPACE"], Name: name}, cur)).To(Succeed())
-			g.Expect(cur.Labels[GITHUB_TEAM_LABEL_FORCE_RECONCILE]).NotTo(Equal(GITHUB_TEAM_LABEL_FORCE_RECONCILE_VALUE))
+			g.Expect(cur.Labels).NotTo(HaveKey(GITHUB_TEAM_LABEL_FORCE_RECONCILE))
 			g.Expect(cur.Status.TeamStatusError).NotTo(Equal(sentinelError))
 		}, 3*timeout, interval).Should(Succeed())
 	})

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -115,14 +115,20 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Update metrics to reflect current state at the beginning of reconcile
 	ghmetrics.SetGithubOrganizationMetrics(githubOrganization)
 
-	// If the forceReconcile label is present, wipe the status first, then remove the label,
-	// and requeue so the next reconcile starts with a clean slate regardless of any stuck state.
-	// Status is reset before the label is removed so that if the label update fails the trigger
-	// is not silently lost — the user can retry by setting the label again.
+	// If the forceReconcile label is present, wipe the status first (via safeStatusUpdate so
+	// payload metrics stay accurate and the write is conflict-retried), re-GET the object to
+	// obtain a current resourceVersion, then remove the label.  Status is reset before the label
+	// is removed so that if the label Update fails the trigger is not silently lost — the user
+	// can retry by setting the label again.
 	if githubOrganization.Labels[GITHUB_ORG_LABEL_FORCE_RECONCILE] == GITHUB_ORG_LABEL_FORCE_RECONCILE_VALUE {
-		githubOrganization.Status = v1.GithubOrganizationStatus{}
-		if err = r.Client.Status().Update(ctx, githubOrganization); err != nil {
+		emptyStatus := v1.GithubOrganizationStatus{}
+		if err = r.safeStatusUpdate(ctx, req, &emptyStatus, githubOrganization, githubOrganization.Spec.Github); err != nil {
 			l.Error(err, "failed to reset status after forceReconcile")
+			return reconcile.Result{}, err
+		}
+		// Re-GET to pick up the new resourceVersion produced by the status write above.
+		if err = r.Get(ctx, req.NamespacedName, githubOrganization); err != nil {
+			l.Error(err, "failed to re-read organization after forceReconcile status reset")
 			return reconcile.Result{}, err
 		}
 		delete(githubOrganization.Labels, GITHUB_ORG_LABEL_FORCE_RECONCILE)

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -115,17 +115,19 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Update metrics to reflect current state at the beginning of reconcile
 	ghmetrics.SetGithubOrganizationMetrics(githubOrganization)
 
-	// If the forceReconcile label is present, remove it, wipe the status, and requeue so
-	// the next reconcile starts with a clean slate regardless of any stuck state.
+	// If the forceReconcile label is present, wipe the status first, then remove the label,
+	// and requeue so the next reconcile starts with a clean slate regardless of any stuck state.
+	// Status is reset before the label is removed so that if the label update fails the trigger
+	// is not silently lost — the user can retry by setting the label again.
 	if githubOrganization.Labels[GITHUB_ORG_LABEL_FORCE_RECONCILE] == GITHUB_ORG_LABEL_FORCE_RECONCILE_VALUE {
-		delete(githubOrganization.Labels, GITHUB_ORG_LABEL_FORCE_RECONCILE)
-		if err = r.Update(ctx, githubOrganization); err != nil {
-			l.Error(err, "failed to remove forceReconcile label")
-			return reconcile.Result{}, err
-		}
 		githubOrganization.Status = v1.GithubOrganizationStatus{}
 		if err = r.Client.Status().Update(ctx, githubOrganization); err != nil {
 			l.Error(err, "failed to reset status after forceReconcile")
+			return reconcile.Result{}, err
+		}
+		delete(githubOrganization.Labels, GITHUB_ORG_LABEL_FORCE_RECONCILE)
+		if err = r.Update(ctx, githubOrganization); err != nil {
+			l.Error(err, "failed to remove forceReconcile label")
 			return reconcile.Result{}, err
 		}
 		l.Info("forceReconcile label detected: status cleared, requeueing")

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -115,6 +115,23 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Update metrics to reflect current state at the beginning of reconcile
 	ghmetrics.SetGithubOrganizationMetrics(githubOrganization)
 
+	// If the forceReconcile label is present, remove it, wipe the status, and requeue so
+	// the next reconcile starts with a clean slate regardless of any stuck state.
+	if githubOrganization.Labels[GITHUB_ORG_LABEL_FORCE_RECONCILE] == GITHUB_ORG_LABEL_FORCE_RECONCILE_VALUE {
+		delete(githubOrganization.Labels, GITHUB_ORG_LABEL_FORCE_RECONCILE)
+		if err = r.Update(ctx, githubOrganization); err != nil {
+			l.Error(err, "failed to remove forceReconcile label")
+			return reconcile.Result{}, err
+		}
+		githubOrganization.Status = v1.GithubOrganizationStatus{}
+		if err = r.Client.Status().Update(ctx, githubOrganization); err != nil {
+			l.Error(err, "failed to reset status after forceReconcile")
+			return reconcile.Result{}, err
+		}
+		l.Info("forceReconcile label detected: status cleared, requeueing")
+		return reconcile.Result{Requeue: true}, nil
+	}
+
 	// If previously rate-limited, honor retry time from the stored error message
 	if githubOrganization.Status.OrganizationStatus == v1.GithubOrganizationStateRateLimited && githubOrganization.Status.OrganizationStatusError != "" {
 		if resetAt, ok := parseGitHubRateLimitReset(githubOrganization.Status.OrganizationStatusError); ok {
@@ -1638,6 +1655,12 @@ const GITHUB_ORG_LABEL_REMOVE_REPOSITORY_DIRECT_COLLABORATOR_DRYRUN_VALUE = "dry
 
 // Annotation written when adaptive TTL shrinking is applied to keep status payload under the safety threshold.
 const GITHUB_ORG_ANNOTATION_STATUS_PAYLOAD_TRUNCATED = "repo-guard.cloudoperators.dev/statusPayloadTruncated"
+
+// Label that, when set to "true", causes the controller to wipe the resource status and requeue
+// for a clean full reconcile — bypassing any ratelimited/failed holdoff.
+// The label is removed by the controller after it is processed.
+const GITHUB_ORG_LABEL_FORCE_RECONCILE = "repo-guard.cloudoperators.dev/forceReconcile"
+const GITHUB_ORG_LABEL_FORCE_RECONCILE_VALUE = "true"
 
 // ttlExpired parses a duration string (e.g., "24h", "30m") and checks if since+TTL is before now.
 func ttlExpired(ttlStr string, since time.Time, now time.Time) (bool, error) {

--- a/internal/controller/githuborganization_controller.go
+++ b/internal/controller/githuborganization_controller.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -116,23 +117,23 @@ func (r *GithubOrganizationReconciler) Reconcile(ctx context.Context, req ctrl.R
 	ghmetrics.SetGithubOrganizationMetrics(githubOrganization)
 
 	// If the forceReconcile label is present, wipe the status first (via safeStatusUpdate so
-	// payload metrics stay accurate and the write is conflict-retried), re-GET the object to
-	// obtain a current resourceVersion, then remove the label.  Status is reset before the label
-	// is removed so that if the label Update fails the trigger is not silently lost — the user
-	// can retry by setting the label again.
+	// payload metrics stay accurate and the write is conflict-retried), then remove the label
+	// inside a RetryOnConflict loop.  Status is reset before the label is removed so that if
+	// the label Update fails the trigger is not silently lost — the user can retry by re-setting
+	// the label.
 	if githubOrganization.Labels[GITHUB_ORG_LABEL_FORCE_RECONCILE] == GITHUB_ORG_LABEL_FORCE_RECONCILE_VALUE {
 		emptyStatus := v1.GithubOrganizationStatus{}
 		if err = r.safeStatusUpdate(ctx, req, &emptyStatus, githubOrganization, githubOrganization.Spec.Github); err != nil {
 			l.Error(err, "failed to reset status after forceReconcile")
 			return reconcile.Result{}, err
 		}
-		// Re-GET to pick up the new resourceVersion produced by the status write above.
-		if err = r.Get(ctx, req.NamespacedName, githubOrganization); err != nil {
-			l.Error(err, "failed to re-read organization after forceReconcile status reset")
-			return reconcile.Result{}, err
-		}
-		delete(githubOrganization.Labels, GITHUB_ORG_LABEL_FORCE_RECONCILE)
-		if err = r.Update(ctx, githubOrganization); err != nil {
+		if err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if rerr := r.Get(ctx, req.NamespacedName, githubOrganization); rerr != nil {
+				return rerr
+			}
+			delete(githubOrganization.Labels, GITHUB_ORG_LABEL_FORCE_RECONCILE)
+			return r.Update(ctx, githubOrganization)
+		}); err != nil {
 			l.Error(err, "failed to remove forceReconcile label")
 			return reconcile.Result{}, err
 		}

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -85,16 +85,27 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// If the forceReconcile label is present, wipe the status first, then remove the label,
 	// and requeue so the next reconcile starts with a clean slate regardless of any stuck state.
-	// Status is reset before the label is removed so that if the label update fails the trigger
-	// is not silently lost — the user can retry by setting the label again.
+	// Both writes are wrapped in RetryOnConflict; the object is re-GET-ed between them so the
+	// label Update uses a current resourceVersion.  Status is reset before the label is removed
+	// so that if the label Update fails the trigger is not silently lost — the user can retry.
 	if githubTeam.Labels[GITHUB_TEAM_LABEL_FORCE_RECONCILE] == GITHUB_TEAM_LABEL_FORCE_RECONCILE_VALUE {
-		githubTeam.Status = v1.GithubTeamStatus{}
-		if err = r.Client.Status().Update(ctx, githubTeam); err != nil {
+		if err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if rerr := r.Get(ctx, req.NamespacedName, githubTeam); rerr != nil {
+				return rerr
+			}
+			githubTeam.Status = v1.GithubTeamStatus{}
+			return r.Client.Status().Update(ctx, githubTeam)
+		}); err != nil {
 			l.Error(err, "failed to reset status after forceReconcile")
 			return reconcile.Result{}, err
 		}
-		delete(githubTeam.Labels, GITHUB_TEAM_LABEL_FORCE_RECONCILE)
-		if err = r.Update(ctx, githubTeam); err != nil {
+		if err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if rerr := r.Get(ctx, req.NamespacedName, githubTeam); rerr != nil {
+				return rerr
+			}
+			delete(githubTeam.Labels, GITHUB_TEAM_LABEL_FORCE_RECONCILE)
+			return r.Update(ctx, githubTeam)
+		}); err != nil {
 			l.Error(err, "failed to remove forceReconcile label")
 			return reconcile.Result{}, err
 		}

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -83,17 +83,19 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// update metrics to reflect current state at the beginning of reconcile
 	ghmetrics.SetGithubTeamMetrics(githubTeam)
 
-	// If the forceReconcile label is present, remove it, wipe the status, and requeue so
-	// the next reconcile starts with a clean slate regardless of any stuck state.
+	// If the forceReconcile label is present, wipe the status first, then remove the label,
+	// and requeue so the next reconcile starts with a clean slate regardless of any stuck state.
+	// Status is reset before the label is removed so that if the label update fails the trigger
+	// is not silently lost — the user can retry by setting the label again.
 	if githubTeam.Labels[GITHUB_TEAM_LABEL_FORCE_RECONCILE] == GITHUB_TEAM_LABEL_FORCE_RECONCILE_VALUE {
-		delete(githubTeam.Labels, GITHUB_TEAM_LABEL_FORCE_RECONCILE)
-		if err = r.Update(ctx, githubTeam); err != nil {
-			l.Error(err, "failed to remove forceReconcile label")
-			return reconcile.Result{}, err
-		}
 		githubTeam.Status = v1.GithubTeamStatus{}
 		if err = r.Client.Status().Update(ctx, githubTeam); err != nil {
 			l.Error(err, "failed to reset status after forceReconcile")
+			return reconcile.Result{}, err
+		}
+		delete(githubTeam.Labels, GITHUB_TEAM_LABEL_FORCE_RECONCILE)
+		if err = r.Update(ctx, githubTeam); err != nil {
+			l.Error(err, "failed to remove forceReconcile label")
 			return reconcile.Result{}, err
 		}
 		l.Info("forceReconcile label detected: status cleared, requeueing")

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -83,6 +83,23 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// update metrics to reflect current state at the beginning of reconcile
 	ghmetrics.SetGithubTeamMetrics(githubTeam)
 
+	// If the forceReconcile label is present, remove it, wipe the status, and requeue so
+	// the next reconcile starts with a clean slate regardless of any stuck state.
+	if githubTeam.Labels[GITHUB_TEAM_LABEL_FORCE_RECONCILE] == GITHUB_TEAM_LABEL_FORCE_RECONCILE_VALUE {
+		delete(githubTeam.Labels, GITHUB_TEAM_LABEL_FORCE_RECONCILE)
+		if err = r.Update(ctx, githubTeam); err != nil {
+			l.Error(err, "failed to remove forceReconcile label")
+			return reconcile.Result{}, err
+		}
+		githubTeam.Status = v1.GithubTeamStatus{}
+		if err = r.Client.Status().Update(ctx, githubTeam); err != nil {
+			l.Error(err, "failed to reset status after forceReconcile")
+			return reconcile.Result{}, err
+		}
+		l.Info("forceReconcile label detected: status cleared, requeueing")
+		return reconcile.Result{Requeue: true}, nil
+	}
+
 	// If previously rate-limited, honor retry time from the stored error message
 	if githubTeam.Status.TeamStatus == v1.GithubTeamStateRateLimited && githubTeam.Status.TeamStatusError != "" {
 		if resetAt, ok := parseGitHubRateLimitReset(githubTeam.Status.TeamStatusError); ok {
@@ -1477,6 +1494,12 @@ const GITHUB_TEAM_LABEL_FAILED_TTL = "repo-guard.cloudoperators.dev/failedTTL"
 const GITHUB_TEAM_LABEL_COMPLETED_TTL = "repo-guard.cloudoperators.dev/completedTTL"
 const GITHUB_TEAM_LABEL_NOTFOUND_TTL = "repo-guard.cloudoperators.dev/notfoundTTL"
 const GITHUB_TEAM_LABEL_SKIPPED_TTL = "repo-guard.cloudoperators.dev/skippedTTL"
+
+// Label that, when set to "true", causes the controller to wipe the resource status and requeue
+// for a clean full reconcile — bypassing any ratelimited/failed holdoff.
+// The label is removed by the controller after it is processed.
+const GITHUB_TEAM_LABEL_FORCE_RECONCILE = "repo-guard.cloudoperators.dev/forceReconcile"
+const GITHUB_TEAM_LABEL_FORCE_RECONCILE_VALUE = "true"
 
 // recordTeamRateLimitHit records a rate-limit event for the team controller and observes the backoff.
 func recordTeamRateLimitHit(errMsg string, resetAt time.Time) {

--- a/internal/controller/test_helpers_test.go
+++ b/internal/controller/test_helpers_test.go
@@ -141,6 +141,39 @@ func updateStatusWithRetry[T client.Object](ctx context.Context, c client.Client
 	return lastErr
 }
 
+// labelWithRetry sets a single label on the object, retrying on conflict.
+func labelWithRetry[T client.Object](ctx context.Context, c client.Client, keyObj T, key, value string) error {
+	deadline := time.Now().Add(20 * time.Second)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		cur := keyObj.DeepCopyObject().(T)
+		if err := c.Get(ctx, types.NamespacedName{Name: keyObj.GetName(), Namespace: keyObj.GetNamespace()}, cur); err != nil {
+			lastErr = err
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+
+		labels := cur.GetLabels()
+		if labels == nil {
+			labels = map[string]string{}
+		}
+		labels[key] = value
+		cur.SetLabels(labels)
+
+		if err := c.Update(ctx, cur); err != nil {
+			if apierrors.IsConflict(err) {
+				lastErr = err
+				time.Sleep(200 * time.Millisecond)
+				continue
+			}
+			return err
+		}
+		return nil
+	}
+	return lastErr
+}
+
 // githubEnsureTeam ensures a team exists in the org (idempotent).
 // If the team already exists, it returns nil.
 // In mock mode (GITHUB_MOCK=true) this is a no-op because teams are pre-seeded

--- a/internal/controller/test_helpers_test.go
+++ b/internal/controller/test_helpers_test.go
@@ -143,35 +143,14 @@ func updateStatusWithRetry[T client.Object](ctx context.Context, c client.Client
 
 // labelWithRetry sets a single label on the object, retrying on conflict.
 func labelWithRetry[T client.Object](ctx context.Context, c client.Client, keyObj T, key, value string) error {
-	deadline := time.Now().Add(20 * time.Second)
-	var lastErr error
-
-	for time.Now().Before(deadline) {
-		cur := keyObj.DeepCopyObject().(T)
-		if err := c.Get(ctx, types.NamespacedName{Name: keyObj.GetName(), Namespace: keyObj.GetNamespace()}, cur); err != nil {
-			lastErr = err
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
-
+	return updateObjectWithRetry(ctx, c, keyObj, func(cur T) {
 		labels := cur.GetLabels()
 		if labels == nil {
 			labels = map[string]string{}
 		}
 		labels[key] = value
 		cur.SetLabels(labels)
-
-		if err := c.Update(ctx, cur); err != nil {
-			if apierrors.IsConflict(err) {
-				lastErr = err
-				time.Sleep(200 * time.Millisecond)
-				continue
-			}
-			return err
-		}
-		return nil
-	}
-	return lastErr
+	})
 }
 
 // githubEnsureTeam ensures a team exists in the org (idempotent).


### PR DESCRIPTION
## Summary

- Adds a `repo-guard.cloudoperators.dev/forceReconcile: "true"` label to both `GithubOrganization` and `GithubTeam` controllers
- When the controller sees the label it removes it, wipes the status subresource to `{}`, and returns `Requeue: true` — bypassing any ratelimited/failed holdoff so the next reconcile starts from a clean slate
- Replaces the manual workaround of patching the status subresource directly

## Usage

```bash
# Force reconcile a stuck team
kubectl label githubteam <name> -n <ns> \
  repo-guard.cloudoperators.dev/forceReconcile=true

# Force reconcile a stuck org
kubectl label githuborganization <name> -n <ns> \
  repo-guard.cloudoperators.dev/forceReconcile=true
```

## Test plan

- [ ] `make controller-test` passes (new `force_reconcile_test.go` covers both GithubOrganization and GithubTeam)
- [ ] Label is removed by the controller after processing (one-shot semantics)
- [ ] Status is cleared and a fresh reconcile runs after the label fires