### PR TITLE
fix(controller): self-heal GithubTeam stuck in failed after transient provider error

### DIFF
--- a/api/v1/githubteam_types.go
+++ b/api/v1/githubteam_types.go
@@ -213,6 +213,7 @@ func (github GithubTeam) ChangeCalculator(desiredMembers []Member) (bool, *Githu
 
 	if changed {
 		newStatus.TeamStatus = GithubTeamStatePendingOperations
+		newStatus.TeamStatusError = ""
 		newStatus.TeamStatusTimestamp = metav1.Now()
 	}
 

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -1043,8 +1043,8 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			// is now healthy and there is nothing to do.
 			if githubTeam.Status.TeamStatus == "" || githubTeam.Status.TeamStatus == v1.GithubTeamStateFailed {
 				l.Info("TeamStatus is empty or failed with no pending changes, setting to complete")
+				latest := &v1.GithubTeam{}
 				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-					latest := &v1.GithubTeam{}
 					if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
 						return err
 					}
@@ -1067,6 +1067,9 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					l.Error(err, "error during status update")
 					return reconcile.Result{}, err
 				}
+				// Sync the in-memory object so the deferred metrics/failure-counter
+				// at the top of Reconcile reflects the status we just wrote.
+				githubTeam.Status = latest.Status
 			}
 		}
 

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -1037,15 +1037,19 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return reconcile.Result{}, nil
 
 		} else {
-			// check for empty status in kubernetes resource
-			if githubTeam.Status.TeamStatus == "" {
-				l.Info("TeamStatus is empty, it could be the first round of the resource reconciliation")
+			// No diff from ChangeCalculator — team is already in desired state.
+			// If the current status is failed (e.g., from a prior transient provider error)
+			// or empty (first reconcile), write complete to reflect that the provider
+			// is now healthy and there is nothing to do.
+			if githubTeam.Status.TeamStatus == "" || githubTeam.Status.TeamStatus == v1.GithubTeamStateFailed {
+				l.Info("TeamStatus is empty or failed with no pending changes, setting to complete")
 				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					latest := &v1.GithubTeam{}
 					if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
 						return err
 					}
 					latest.Status.TeamStatus = v1.GithubTeamStateComplete
+					latest.Status.TeamStatusError = ""
 					latest.Status.TeamStatusTimestamp = metav1.Now()
 					return r.Client.Status().Update(ctx, latest)
 				})

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -1042,7 +1042,6 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			// or empty (first reconcile), write complete to reflect that the provider
 			// is now healthy and there is nothing to do.
 			if githubTeam.Status.TeamStatus == "" || githubTeam.Status.TeamStatus == v1.GithubTeamStateFailed {
-				l.Info("TeamStatus is empty or failed with no pending changes, setting to complete")
 				latest := &v1.GithubTeam{}
 				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
@@ -1058,6 +1057,7 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					if latest.PendingOperationsFound() || latest.FailedOperationsFound() {
 						return nil
 					}
+					l.Info("TeamStatus is empty or failed with no pending changes, setting to complete")
 					latest.Status.TeamStatus = v1.GithubTeamStateComplete
 					latest.Status.TeamStatusError = ""
 					latest.Status.TeamStatusTimestamp = metav1.Now()

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -1048,6 +1048,11 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					if err := r.Get(ctx, req.NamespacedName, latest); err != nil {
 						return err
 					}
+					// Re-check on the freshly fetched object to avoid clobbering a
+					// concurrent status write that moved the resource out of failed/empty.
+					if latest.Status.TeamStatus != "" && latest.Status.TeamStatus != v1.GithubTeamStateFailed {
+						return nil
+					}
 					latest.Status.TeamStatus = v1.GithubTeamStateComplete
 					latest.Status.TeamStatusError = ""
 					latest.Status.TeamStatusTimestamp = metav1.Now()

--- a/internal/controller/githubteam_controller.go
+++ b/internal/controller/githubteam_controller.go
@@ -1050,7 +1050,12 @@ func (r *GithubTeamReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 					}
 					// Re-check on the freshly fetched object to avoid clobbering a
 					// concurrent status write that moved the resource out of failed/empty.
+					// Also skip if there are still pending or failed operations — those
+					// must be resolved before the team can be considered complete.
 					if latest.Status.TeamStatus != "" && latest.Status.TeamStatus != v1.GithubTeamStateFailed {
+						return nil
+					}
+					if latest.PendingOperationsFound() || latest.FailedOperationsFound() {
 						return nil
 					}
 					latest.Status.TeamStatus = v1.GithubTeamStateComplete

--- a/internal/controller/githubteam_controller_test.go
+++ b/internal/controller/githubteam_controller_test.go
@@ -412,7 +412,7 @@ var _ = Describe("Github Team controller — transient external provider errors"
 				return ""
 			}
 			return cur3.Status.TeamStatus
-		}, 3*timeout, interval).ShouldNot(Equal(repoguardsapv1.GithubTeamState(repoguardsapv1.GithubTeamStateFailed)),
-			"team should leave failed state once the provider recovers")
+		}, 3*timeout, interval).Should(Equal(repoguardsapv1.GithubTeamState(repoguardsapv1.GithubTeamStateComplete)),
+			"team should transition to complete once the provider recovers")
 	})
 })

--- a/internal/controller/githubteam_controller_test.go
+++ b/internal/controller/githubteam_controller_test.go
@@ -414,5 +414,11 @@ var _ = Describe("Github Team controller — transient external provider errors"
 			return cur3.Status.TeamStatus
 		}, 3*timeout, interval).Should(Equal(repoguardsapv1.GithubTeamState(repoguardsapv1.GithubTeamStateComplete)),
 			"team should transition to complete once the provider recovers")
+
+		// 3. Verify the stale error message was also cleared.
+		cur4 := &repoguardsapv1.GithubTeam{}
+		Expect(k8sClient.Get(ctx, teamKey, cur4)).To(Succeed())
+		Expect(cur4.Status.TeamStatusError).To(BeEmpty(),
+			"TeamStatusError should be cleared when transitioning to complete")
 	})
 })


### PR DESCRIPTION
## Summary

- When an external member provider returned a transient error (e.g. HTTP 502), the controller wrote `TeamStatus=failed`. After the provider recovered, if membership was unchanged `ChangeCalculator` returned `statusChanged=false` and the `else` branch only reset status when `TeamStatus==""`. Teams with `TeamStatus=="failed"` were never cleared and stayed stuck indefinitely.
- Fix extends the condition to `TeamStatus == "" || TeamStatus == failed`, and also clears `TeamStatusError` to remove the stale error message when transitioning to `complete`.
- Strengthens the existing transient-error test assertion from `ShouldNot(Equal(failed))` to `Should(Equal(complete))`.

## Test plan

- [x] `make controller-test` — all 36 specs pass, including the updated transient-error self-heal scenario
- [ ] Deploy to staging and verify that teams currently stuck in `failed` self-heal on next reconcile (or apply `forceReconcile` label to unblock immediately)